### PR TITLE
Implement inheritance strategy for Triggers

### DIFF
--- a/ramls/eventtrigger.json
+++ b/ramls/eventtrigger.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "EventTrigger",
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "deserializeAs" : {
+      "type" : "string",
+      "enum" : [ "EventTrigger" ],
+      "default" : "EventTrigger"
+    },
+    "id" : {
+      "type" : "string"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 64
+    },
+    "description" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 256
+    },
+    "type" : {
+      "type" : "string",
+      "enum" : [ "PROCESS_START", "TASK_COMPLETE", "MESSAGE_CORRELATE" ]
+    },
+    "method" : {
+      "type" : "string",
+      "enum" : [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE" ]
+    },
+    "pathPattern" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "deserializeAs", "name", "description", "type", "method", "pathPattern" ]
+}

--- a/ramls/manualtrigger.json
+++ b/ramls/manualtrigger.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "ManualTrigger",
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "deserializeAs" : {
+      "type" : "string",
+      "enum" : [ "ManualTrigger" ],
+      "default" : "ManualTrigger"
+    },
+    "id" : {
+      "type" : "string"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 64
+    },
+    "description" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 256
+    },
+    "type" : {
+      "type" : "string",
+      "enum" : [ "PROCESS_START", "TASK_COMPLETE", "MESSAGE_CORRELATE" ]
+    },
+    "method" : {
+      "type" : "string",
+      "enum" : [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE" ]
+    },
+    "pathPattern" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "deserializeAs", "name", "description", "type", "method", "pathPattern" ]
+}

--- a/ramls/scheduletrigger.json
+++ b/ramls/scheduletrigger.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "ScheduleTrigger",
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "deserializeAs" : {
+      "type" : "string",
+      "enum" : [ "ScheduleTrigger" ],
+      "default" : "ScheduleTrigger"
+    },
+    "id" : {
+      "type" : "string"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 64
+    },
+    "description" : {
+      "type" : "string",
+      "minLength" : 4,
+      "maxLength" : 256
+    },
+    "type" : {
+      "type" : "string",
+      "enum" : [ "PROCESS_START", "TASK_COMPLETE", "MESSAGE_CORRELATE" ]
+    },
+    "method" : {
+      "type" : "string",
+      "enum" : [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE" ]
+    },
+    "pathPattern" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "deserializeAs", "name", "description", "type", "method", "pathPattern" ]
+}

--- a/src/main/java/org/folio/rest/model/EventTrigger.java
+++ b/src/main/java/org/folio/rest/model/EventTrigger.java
@@ -1,0 +1,8 @@
+package org.folio.rest.model;
+
+import javax.persistence.Entity;
+
+@Entity
+public class EventTrigger extends Trigger {
+
+}

--- a/src/main/java/org/folio/rest/model/ManualTrigger.java
+++ b/src/main/java/org/folio/rest/model/ManualTrigger.java
@@ -1,0 +1,8 @@
+package org.folio.rest.model;
+
+import javax.persistence.Entity;
+
+@Entity
+public class ManualTrigger extends Trigger {
+
+}

--- a/src/main/java/org/folio/rest/model/ScheduleTrigger.java
+++ b/src/main/java/org/folio/rest/model/ScheduleTrigger.java
@@ -1,0 +1,8 @@
+package org.folio.rest.model;
+
+import javax.persistence.Entity;
+
+@Entity
+public class ScheduleTrigger extends Trigger {
+
+}

--- a/src/main/java/org/folio/rest/model/Task.java
+++ b/src/main/java/org/folio/rest/model/Task.java
@@ -14,7 +14,7 @@ import org.folio.rest.domain.model.AbstractBaseEntity;
 
 @Entity(name="tasks")
 @Inheritance
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "deserializeAs")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ProcessorTask.class, name = "ProcessorTask"),
 
@@ -38,7 +38,7 @@ public abstract class Task extends AbstractBaseEntity {
   private String delegate;
 
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-  private String type = this.getClass().getSimpleName();
+  private String deserializeAs = this.getClass().getSimpleName();
 
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private Boolean streaming;
@@ -64,12 +64,12 @@ public abstract class Task extends AbstractBaseEntity {
     this.delegate = delegate;
   }
 
-  public String getType() {
-    return type;
+  public String getDeserializeAs() {
+    return deserializeAs;
   }
 
-  public void setType(String type) {
-    this.type = type;
+  public void setDeserializeAs(String deserializeAs) {
+    this.deserializeAs = deserializeAs;
   }
 
   public Boolean isStreaming() {

--- a/src/main/java/org/folio/rest/model/Trigger.java
+++ b/src/main/java/org/folio/rest/model/Trigger.java
@@ -4,6 +4,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -11,8 +12,21 @@ import org.folio.rest.domain.model.AbstractBaseEntity;
 import org.folio.rest.jms.model.TriggerType;
 import org.springframework.http.HttpMethod;
 
-@Entity
-public class Trigger extends AbstractBaseEntity {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@Entity(name="triggers")
+@Inheritance
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "deserializeAs" )
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = EventTrigger.class, name = "EventTrigger"),
+
+  @JsonSubTypes.Type(value = ManualTrigger.class, name = "ManualTrigger"),
+
+  @JsonSubTypes.Type(value = ScheduleTrigger.class, name = "ScheduleTrigger")
+})
+public abstract class Trigger extends AbstractBaseEntity {
 
   @NotNull
   @Size(min = 4, max = 64)
@@ -35,6 +49,9 @@ public class Trigger extends AbstractBaseEntity {
   @NotNull
   @Column
   private String pathPattern;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String deserializeAs = this.getClass().getSimpleName();
 
   public Trigger() {
     super();
@@ -87,6 +104,14 @@ public class Trigger extends AbstractBaseEntity {
 
   public void setPathPattern(String pathPattern) {
     this.pathPattern = pathPattern;
+  }
+
+  public String getDeserializeAs() {
+    return deserializeAs;
+  }
+
+  public void setDeserializeAs(String deserializeAs) {
+    this.deserializeAs = deserializeAs;
   }
 
 }


### PR DESCRIPTION
EventTrigger, ManualTrigger, and ScheduleTrigger are only stubbed out.
Specific implementations of each of those will be handled in separate commits.

Refactored Task.type to deserializeAs and use deserializeAs in Triggers for consistency.

resolves #8 