### PR TITLE
[Issue 124] Purchase Order Workflow: Add email task to end of purchase order workflow.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
@@ -53,6 +53,9 @@ public class EmailTask extends Node implements DelegateTask {
   @Column(columnDefinition = "TEXT", nullable = false)
   private String mailText;
 
+  @Column(columnDefinition = "TEXT", nullable = true)
+  private String mailMarkup;
+
   @Column(nullable = true)
   private String attachmentPath;
 
@@ -145,6 +148,14 @@ public class EmailTask extends Node implements DelegateTask {
 
   public void setMailText(String mailText) {
     this.mailText = mailText;
+  }
+
+  public String getMailMarkup() {
+    return mailMarkup;
+  }
+
+  public void setMailMarkup(String mailMarkup) {
+    this.mailMarkup = mailMarkup;
   }
 
   public String getAttachmentPath() {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -139,6 +139,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-kahadb-store</artifactId>
     </dependency>

--- a/service/ramls/conditionalgateway.json
+++ b/service/ramls/conditionalgateway.json
@@ -728,6 +728,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/ramls/emailtask.json
+++ b/service/ramls/emailtask.json
@@ -61,6 +61,9 @@
       "type" : "string",
       "minLength" : 2
     },
+    "mailMarkup" : {
+      "type" : "string"
+    },
     "attachmentPath" : {
       "type" : "string"
     },

--- a/service/ramls/eventsubprocess.json
+++ b/service/ramls/eventsubprocess.json
@@ -714,6 +714,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/ramls/movetonode.json
+++ b/service/ramls/movetonode.json
@@ -717,6 +717,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/ramls/parallelgateway.json
+++ b/service/ramls/parallelgateway.json
@@ -714,6 +714,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/ramls/subprocess.json
+++ b/service/ramls/subprocess.json
@@ -730,6 +730,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/ramls/workflow.json
+++ b/service/ramls/workflow.json
@@ -741,6 +741,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.workflow.exception.EventPublishException;
 import org.folio.rest.workflow.jms.EventProducer;
 import org.folio.rest.workflow.jms.model.Event;
@@ -67,12 +68,13 @@ public class EventController {
   @PostMapping(value = "/**", consumes = "multipart/form-data")
   public JsonNode postHandleEventsWithFile(
     @RequestParam("file") MultipartFile multipartFile,
-    @RequestParam("path") String filePath,
+    @RequestParam("path") String directoryPath,
     HttpServletRequest request
   ) throws EventPublishException, IOException {
   // @formatter:on
 
     ObjectNode body = objectMapper.createObjectNode();
+    String filePath = StringUtils.appendIfMissing(directoryPath, File.separator) + multipartFile.getOriginalFilename();
     body.put("inputFilePath", filePath);
 
     Collections.list(request.getParameterNames())
@@ -84,6 +86,8 @@ public class EventController {
       });
 
     File file = new File(filePath);
+
+    file.mkdirs();
 
     try (InputStream is = multipartFile.getInputStream()) {
       Files.copy(is, file.toPath(), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
Utilize dynamic and configurable file path.
The path fields need to be template-able.

Properly handle HTML Markup and Plain Text Markup when sending e-mails.
Add `markup`/`mailMarkup` as an optional field (making it backwards compatible with existing workflows).

Add missing dependency to apache commons.

relates TAMULib/fw-registry#124