### PR TITLE
Issue 77: Workflow History API.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -1,7 +1,5 @@
 package org.folio.rest.workflow.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.service.WorkflowEngineService;
@@ -10,12 +8,15 @@ import org.folio.spring.tenant.annotation.TenantHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 @RestController
 @RequestMapping("/workflows")
@@ -55,6 +56,16 @@ public class WorkflowController {
   ) throws WorkflowEngineServiceException {
     logger.info("Starting: {} with context {}", id, context);
     return workflowEngineService.start(id, tenant, token, context);
+  }
+
+  @GetMapping("/{id}/history")
+  public JsonNode workflowHistory(
+    @PathVariable String id,
+    @TenantHeader String tenant,
+    @TokenHeader String token
+  ) throws WorkflowEngineServiceException {
+    logger.debug("Retrieving History: {}", id);
+    return workflowEngineService.history(id, tenant, token);
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
@@ -42,6 +42,9 @@ public class OkapiDiscoveryService {
   @Value("${okapi.url}")
   private String okapiUrl;
 
+  @Value("${okapi.camunda.base-path}")
+  private String basePath;
+
   @Autowired
   private HttpService httpService;
 
@@ -89,7 +92,7 @@ public class OkapiDiscoveryService {
   }
 
   public JsonNode getModules(String tenant) {
-    String url = okapiUrl + PROXY_TENANT_BASE_PATH + tenant + MODULES_SUB_PATH;
+    String url = okapiUrl + basePath + PROXY_TENANT_BASE_PATH + tenant + MODULES_SUB_PATH;
     ResponseEntity<JsonNode> response = request(url, tenant);
     if (logger.isDebugEnabled()) {
       logger.debug("Response status code {}", response.getStatusCode());
@@ -99,7 +102,7 @@ public class OkapiDiscoveryService {
   }
 
   public JsonNode getModuleDescriptor(String tenant, String id) {
-    String url = okapiUrl + PROXY_MODULE_BASE_PATH + id;
+    String url = okapiUrl + basePath + PROXY_MODULE_BASE_PATH + id;
     ResponseEntity<JsonNode> response = request(url, tenant);
     if (logger.isDebugEnabled()) {
       logger.debug("Response status code {}", response.getStatusCode());

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -1,8 +1,5 @@
 package org.folio.rest.workflow.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
@@ -19,13 +16,24 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 @Service
 public class WorkflowEngineService {
 
   private static final Logger logger = LoggerFactory.getLogger(WorkflowEngineService.class);
 
-  private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s/workflow-engine/workflows/activate";
-  private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s/workflow-engine/workflows/deactivate";
+  private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
+  private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";
+
+  private static final String PROCESS_DEFINITION_START_URL_TEMPLATE = "%s%s/process-definition/%s/start";
+  private static final String PROCESS_DEFINITION_GET_URL_TEMPLATE = "%s%s/process-definition%s";
+
+  private static final String HISTORY_PROCESS_INSTANCE_URL_TEMPLATE = "%s%s/history/process-instance%s";
+  private static final String HISTORY_INCIDENT_URL_TEMPLATE = "%s%s/history/incident%s";
 
   @Value("${tenant.headerName:X-Okapi-Tenant}")
   private String tenantHeaderName;
@@ -36,8 +44,17 @@ public class WorkflowEngineService {
   @Value("${okapi.url}")
   private String okapiUrl;
 
+  @Value("${okapi.camunda.base-path}")
+  private String basePath;
+
+  @Value("${okapi.camunda.rest-path}")
+  private String restPath;
+
   @Autowired
   private WorkflowRepo workflowRepo;
+
+  @Autowired
+  ObjectMapper mapper;
 
   private RestTemplate restTemplate;
 
@@ -48,38 +65,61 @@ public class WorkflowEngineService {
   public Workflow activate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
     Workflow workflow = workflowRepo.getOne(workflowId);
-    return sendRequest(workflow, WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE, tenant, token);
+    return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE, tenant, token);
   }
 
   public Workflow deactivate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
     Workflow workflow = workflowRepo.getOne(workflowId);
-    return sendRequest(workflow, WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE, tenant, token);
+    return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE, tenant, token);
   }
 
   public JsonNode start(String workflowId, String tenant, String token, JsonNode context)
       throws WorkflowEngineServiceException {
 
     Workflow workflow = workflowRepo.getOne(workflowId);
+    String id = workflow.getDeploymentId();
+    String version = workflow.getVersionTag();
 
-    JsonNode definition = fetchDefinition(workflow.getDeploymentId(), tenant, token);
+    JsonNode definition = fetchDeploymentDefinition(id, version, tenant, token);
     String definitionId = definition.get("id").asText();
 
     HttpEntity<JsonNode> contextHttpEntity = new HttpEntity<>(context, headers(tenant, token));
 
-    String url = String.format("%s/camunda/process-definition/%s/start", okapiUrl, definitionId);
+    String url = String.format(PROCESS_DEFINITION_START_URL_TEMPLATE, okapiUrl, restPath, definitionId);
     ResponseEntity<JsonNode> response = exchange(url, HttpMethod.POST, contextHttpEntity, JsonNode.class);
 
     return response.getBody();
   }
 
-  private JsonNode fetchDefinition(String deploymentId, String tenant, String token)
+  public JsonNode history(String workflowId, String tenant, String token) throws WorkflowEngineServiceException {
+    Workflow workflow = workflowRepo.getOne(workflowId);
+    String deploymentId = workflow.getDeploymentId();
+    String version = workflow.getVersionTag();
+
+    JsonNode processDefinition = fetchDeploymentDefinition(deploymentId, version, tenant, token);
+    String processDefinitionId = processDefinition.get("id").asText();
+
+    ArrayNode instances = fetchProcessInstanceHistory(processDefinitionId, tenant, token);
+
+    instances.forEach(instance -> {
+      String processInstanceId = instance.get("id").asText();
+
+      ((ObjectNode) instance).withArray("incidents")
+        .addAll(fetchIncidentsHistory(processInstanceId, tenant, token));
+    });
+
+    return instances;
+  }
+
+  private JsonNode fetchDeploymentDefinition(String deploymentId, String version, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    HttpEntity<Void> definitionEntity = new HttpEntity<>(headers(tenant, token));
+    HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
 
-    String definitionsUrl = String.format("%s/camunda/process-definition?deploymentId=%s", okapiUrl, deploymentId);
-    ResponseEntity<ArrayNode> response = exchange(definitionsUrl, HttpMethod.GET, definitionEntity, ArrayNode.class);
+    String arguments = String.format("?deploymentId=%s&versionTag=%s&maxResults=1", deploymentId, version);
+    String url = String.format(PROCESS_DEFINITION_GET_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
 
     ArrayNode definitions = response.getBody();
     if (response.getStatusCode() == HttpStatus.OK && definitions != null && !definitions.isEmpty()) {
@@ -91,12 +131,52 @@ public class WorkflowEngineService {
     throw new WorkflowEngineServiceException("Unable to get workflow process definition from workflow engine!");
   }
 
-  private Workflow sendRequest(Workflow workflow, String requestPath, String tenant, String token)
+  private ArrayNode fetchProcessInstanceHistory(String processDefinitionId, String tenant, String token)
+      throws WorkflowEngineServiceException {
+
+    HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
+
+    String arguments = String.format("?processDefinitionId=%s&sortBy=startTime&sortOrder=asc", processDefinitionId);
+    String url = String.format(HISTORY_PROCESS_INSTANCE_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
+
+    ArrayNode definitions = response.getBody();
+    if (response.getStatusCode() == HttpStatus.OK && definitions != null) {
+      logger.debug("Response body: {}", definitions);
+
+      return definitions;
+    }
+
+    throw new WorkflowEngineServiceException("Unable to get workflow process instance history from workflow engine!");
+  }
+
+  private ArrayNode fetchIncidentsHistory(String processInstanceId, String tenant, String token) {
+
+    HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
+
+    String arguments = String.format("?processInstanceId=%s&sortBy=createTime&sortOrder=asc", processInstanceId);
+    String url = String.format(HISTORY_INCIDENT_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
+
+    ArrayNode incidents = response.getBody();
+    if (response.getStatusCode() == HttpStatus.OK && incidents != null) {
+      logger.debug("Response body: {}", incidents);
+    }
+    else {
+      logger.debug("Unable to get workflow incidents history from workflow engine!");
+
+      incidents = mapper.createArrayNode();
+    }
+
+    return incidents;
+  }
+
+  private Workflow sendWorkflowRequest(Workflow workflow, String requestPath, String tenant, String token)
       throws WorkflowEngineServiceException {
 
     HttpEntity<Workflow> workflowHttpEntity = new HttpEntity<>(workflow, headers(tenant, token));
 
-    String url = String.format(requestPath, okapiUrl);
+    String url = String.format(requestPath, okapiUrl, basePath);
     ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, workflowHttpEntity, Workflow.class);
 
     Workflow responseWorkflow = response.getBody();
@@ -104,7 +184,7 @@ public class WorkflowEngineService {
       logger.debug("Response body: {}", responseWorkflow);
 
       String deploymentId = responseWorkflow.getDeploymentId();
-      logger.info("Workflow is actvie = {}, deploymentID = {}", responseWorkflow.isActive(), deploymentId);
+      logger.info("Workflow is active = {}, deploymentID = {}", responseWorkflow.isActive(), deploymentId);
       return workflowRepo.save(responseWorkflow);
     }
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -62,7 +62,11 @@ tenant:
     - org.folio.rest.workflow.model
   schema-scripts:
 
-okapi.url: http://localhost:9000/mod-camunda
+okapi:
+  url: http://localhost:9000
+  camunda:
+    base-path: /mod-camunda
+    rest-path: /mod-camunda/rest
 
 info:
   build:


### PR DESCRIPTION
Mod-Camunda is now settings "camunda" in the `jersey.application-path` to "rest" by default.
Redesign Workflow Engine Service to allow for dynamic customization of this path.
As a result the `okapi.url` is expanded into `okapi.url`, `okapi.camunda.base-path`, and `okapi.camunda.rest-path`.

Workflow learned how to report history at `/workflows/{id}/history` for some workflow by that workflows id.
This utilizes the Camunda REST endpoints: `/process-definition`, `/history/process-instance`, and `/history/incident`.
All process instances are loaded for some workflow and for each instance, all incidents are appended to an added property called `incidents`.

This introduces sorting on the requests to the Camunda REST where appropriate.

This introduces filtering by `versionTag` on the requests to Camunda REST.

resolves #77 