### PR TITLE
Issue 113: Make changes needed to successfully register deploy module.

### DIFF
--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -3,182 +3,182 @@
   "name": "Workflow Module",
   "provides": [
     {
-      "id": "actions",
+      "id": "workflow-actions",
       "version": "1.0",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/actions",
-          "permissionsRequired": ["workflow.action.collection.get"],
-          "permissionsDesired": ["workflow.action.domain.*", "workflow.action.domain.all"]
+          "permissionsRequired": ["workflow.actions.collection.get"],
+          "permissionsDesired": ["workflow.actions.domain.*", "workflow.actions.domain.all"]
         }
       ]
     },
     {
-      "id": "events",
+      "id": "workflow-events",
       "version": "1.0",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/events/*",
-          "permissionsRequired": ["workflow.event.collection.get"],
-          "permissionsDesired": ["workflow.event.domain.*", "workflow.event.domain.all"]
+          "permissionsRequired": ["workflow.events.collection.get"],
+          "permissionsDesired": ["workflow.events.domain.*", "workflow.events.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/events/*",
-          "permissionsRequired": ["workflow.event.collection.post"],
-          "permissionsDesired": ["workflow.event.domain.*", "workflow.event.domain.all"]
+          "permissionsRequired": ["workflow.events.collection.post"],
+          "permissionsDesired": ["workflow.events.domain.*", "workflow.events.domain.all"]
         }
       ]
     },
     {
-      "id": "triggers",
+      "id": "workflow-triggers",
       "version": "1.0",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/triggers",
-          "permissionsRequired": ["workflow.trigger.collection.get"],
-          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
+          "permissionsRequired": ["workflow.triggers.collection.get"],
+          "permissionsDesired": ["workflow.triggers.domain.*", "workflow.triggers.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["workflow.trigger.item.get"],
-          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
+          "permissionsRequired": ["workflow.triggers.item.get"],
+          "permissionsDesired": ["workflow.triggers.domain.*", "workflow.triggers.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/triggers",
-          "permissionsRequired": ["workflow.trigger.item.post"],
-          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
+          "permissionsRequired": ["workflow.triggers.item.post"],
+          "permissionsDesired": ["workflow.triggers.domain.*", "workflow.triggers.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["workflow.trigger.item.put"],
-          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
+          "permissionsRequired": ["workflow.triggers.item.put"],
+          "permissionsDesired": ["workflow.triggers.domain.*", "workflow.triggers.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["workflow.trigger.item.delete"],
-          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
+          "permissionsRequired": ["workflow.triggers.item.delete"],
+          "permissionsDesired": ["workflow.triggers.domain.*", "workflow.triggers.domain.all"]
         }
       ]
     },
     {
-      "id": "tasks",
+      "id": "workflow-tasks",
       "version": "1.0",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/tasks",
-          "permissionsRequired": ["workflow.task.collection.get"],
-          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
+          "permissionsRequired": ["workflow.tasks.collection.get"],
+          "permissionsDesired": ["workflow.tasks.domain.*", "workflow.tasks.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["workflow.task.item.get"],
-          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
+          "permissionsRequired": ["workflow.tasks.item.get"],
+          "permissionsDesired": ["workflow.tasks.domain.*", "workflow.tasks.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/tasks",
-          "permissionsRequired": ["workflow.task.item.post"],
-          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
+          "permissionsRequired": ["workflow.tasks.item.post"],
+          "permissionsDesired": ["workflow.tasks.domain.*", "workflow.tasks.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["workflow.task.item.put"],
-          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
+          "permissionsRequired": ["workflow.tasks.item.put"],
+          "permissionsDesired": ["workflow.tasks.domain.*", "workflow.tasks.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["workflow.task.item.delete"],
-          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
+          "permissionsRequired": ["workflow.tasks.item.delete"],
+          "permissionsDesired": ["workflow.tasks.domain.*", "workflow.tasks.domain.all"]
         }
       ]
     },
     {
-      "id": "workflows",
+      "id": "workflow-workflows",
       "version": "1.0",
       "handlers": [
         {
           "methods": ["GET"],
           "pathPattern": "/workflows",
-          "permissionsRequired": ["workflow.workflow.collection.get"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.collection.get"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.workflow.item.get"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.get"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/workflows",
-          "permissionsRequired": ["workflow.workflow.item.post"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.post"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.workflow.item.put"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.put"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["PATCH"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.workflow.item.patch"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.patch"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.workflow.item.delete"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.delete"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/activate",
-          "permissionsRequired": ["workflow.workflow.item.activate"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.activate"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/deactivate",
-          "permissionsRequired": ["workflow.workflow.item.deactivate"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.deactivate"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}/tasks",
-          "permissionsRequired": ["workflow.workflow.item.tasks"],
-          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflows.item.tasks"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         }
       ]
     },
@@ -218,229 +218,229 @@
   ],
   "permissionSets" : [
     {
-      "permissionName": "workflow.action.collection.get",
+      "permissionName": "workflow.actions.collection.get",
       "displayName": "Action - get action collection",
       "description": "Get action collection"
     },
     {
-      "permissionName": "workflow.action.allops",
+      "permissionName": "workflow.actions.allops",
       "displayName": "Action module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the action modules, but no domain permissions",
       "subPermissions": [
-        "workflow.action.collection.get"
+        "workflow.actions.collection.get"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.action.all",
+      "permissionName": "workflow.actions.all",
       "displayName": "Action module - all permissions and all action domains",
       "description": "Entire set of permissions needed to use the action modules on any action domain",
       "subPermissions": [
-        "workflow.action.allops",
-        "workflow.action.domain.all"
+        "workflow.actions.allops",
+        "workflow.actions.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.event.collection.get",
+      "permissionName": "workflow.events.collection.get",
       "displayName": "Event - emit event",
       "description": "Emit event"
     },
     {
-      "permissionName": "workflow.event.collection.post",
+      "permissionName": "workflow.events.collection.post",
       "displayName": "Event - emit event",
       "description": "Emit event"
     },
     {
-      "permissionName": "workflow.event.allops",
+      "permissionName": "workflow.events.allops",
       "displayName": "Event module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the event modules, but no domain permissions",
       "subPermissions": [
-        "workflow.event.collection.get"
+        "workflow.events.collection.get"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.event.all",
+      "permissionName": "workflow.events.all",
       "displayName": "Event module - all permissions and all event domains",
       "description": "Entire set of permissions needed to use the event modules on any event domain",
       "subPermissions": [
-        "workflow.event.allops",
-        "workflow.event.domain.all"
+        "workflow.events.allops",
+        "workflow.events.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.trigger.collection.get",
+      "permissionName": "workflow.triggers.collection.get",
       "displayName": "Trigger - get trigger collection",
       "description": "Get trigger collection"
     },
     {
-      "permissionName": "workflow.trigger.item.get",
+      "permissionName": "workflow.triggers.item.get",
       "displayName": "Trigger - get trigger item",
       "description": "Get trigger item"
     },
     {
-      "permissionName": "workflow.trigger.item.post",
+      "permissionName": "workflow.triggers.item.post",
       "displayName": "Trigger - post trigger item",
       "description": "Create trigger item"
     },
     {
-      "permissionName": "workflow.trigger.item.put",
+      "permissionName": "workflow.triggers.item.put",
       "displayName": "Trigger - put trigger item",
       "description": "Update trigger item"
     },
     {
-      "permissionName": "workflow.trigger.item.delete",
+      "permissionName": "workflow.triggers.item.delete",
       "displayName": "Trigger - delete trigger item",
       "description": "Delete trigger item"
     },
     {
-      "permissionName": "workflow.trigger.allops",
+      "permissionName": "workflow.triggers.allops",
       "displayName": "Trigger module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the trigger modules, but no domain permissions",
       "subPermissions": [
-        "workflow.trigger.collection.get",
-        "workflow.trigger.item.get",
-        "workflow.trigger.item.post",
-        "workflow.trigger.item.put",
-        "workflow.trigger.item.delete"
+        "workflow.triggers.collection.get",
+        "workflow.triggers.item.get",
+        "workflow.triggers.item.post",
+        "workflow.triggers.item.put",
+        "workflow.triggers.item.delete"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.trigger.all",
+      "permissionName": "workflow.triggers.all",
       "displayName": "Trigger module - all permissions and all trigger domains",
       "description": "Entire set of permissions needed to use the trigger modules on any trigger domain",
       "subPermissions": [
-        "workflow.trigger.allops",
-        "workflow.trigger.domain.all"
+        "workflow.triggers.allops",
+        "workflow.triggers.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.task.collection.get",
+      "permissionName": "workflow.tasks.collection.get",
       "displayName": "Task - get task collection",
       "description": "Get task collection"
     },
     {
-      "permissionName": "workflow.task.item.get",
+      "permissionName": "workflow.tasks.item.get",
       "displayName": "Task - get task item",
       "description": "Get task item"
     },
     {
-      "permissionName": "workflow.task.item.post",
+      "permissionName": "workflow.tasks.item.post",
       "displayName": "Task - post task item",
       "description": "Create task item"
     },
     {
-      "permissionName": "workflow.task.item.put",
+      "permissionName": "workflow.tasks.item.put",
       "displayName": "Task - put task item",
       "description": "Update task item"
     },
     {
-      "permissionName": "workflow.task.item.delete",
+      "permissionName": "workflow.tasks.item.delete",
       "displayName": "Task - delete task item",
       "description": "Delete task item"
     },
     {
-      "permissionName": "workflow.task.allops",
+      "permissionName": "workflow.tasks.allops",
       "displayName": "Task module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the task modules, but no domain permissions",
       "subPermissions": [
-        "workflow.task.collection.get",
-        "workflow.task.item.get",
-        "workflow.task.item.post",
-        "workflow.task.item.put",
-        "workflow.task.item.delete"
+        "workflow.tasks.collection.get",
+        "workflow.tasks.item.get",
+        "workflow.tasks.item.post",
+        "workflow.tasks.item.put",
+        "workflow.tasks.item.delete"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.task.all",
+      "permissionName": "workflow.tasks.all",
       "displayName": "Task module - all permissions and all task domains",
       "description": "Entire set of permissions needed to use the task modules on any task domain",
       "subPermissions": [
-        "workflow.task.allops",
-        "workflow.task.domain.all"
+        "workflow.tasks.allops",
+        "workflow.tasks.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.workflow.collection.get",
+      "permissionName": "workflow.workflows.collection.get",
       "displayName": "Workflow - get workflow collection",
       "description": "Get workflow collection"
     },
     {
-      "permissionName": "workflow.workflow.item.get",
+      "permissionName": "workflow.workflows.item.get",
       "displayName": "Workflow - get workflow item",
       "description": "Get workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.post",
+      "permissionName": "workflow.workflows.item.post",
       "displayName": "Workflow - post workflow item",
       "description": "Create workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.put",
+      "permissionName": "workflow.workflows.item.put",
       "displayName": "Workflow - put workflow item",
       "description": "Update workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.patch",
+      "permissionName": "workflow.workflows.item.patch",
       "displayName": "Workflow - patch workflow item",
       "description": "Patch workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.delete",
+      "permissionName": "workflow.workflows.item.delete",
       "displayName": "Workflow - delete workflow item",
       "description": "Delete workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.startTrigger",
+      "permissionName": "workflow.workflows.item.startTrigger",
       "displayName": "Workflow - add/remove start trigger on workflow item",
       "description": "Add/remove start trigger on workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.activate",
+      "permissionName": "workflow.workflows.item.activate",
       "displayName": "Workflow - activate workflow item",
       "description": "Activate workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.deactivate",
+      "permissionName": "workflow.workflows.item.deactivate",
       "displayName": "Workflow - deactivate workflow item",
       "description": "Dactivate workflow item"
     },
     {
-      "permissionName": "workflow.workflow.item.tasks",
+      "permissionName": "workflow.workflows.item.tasks",
       "displayName": "Workflow - workflow item tasks",
       "description": "Get workflow item tasks"
     },
     {
-      "permissionName": "workflow.workflow.allops",
+      "permissionName": "workflow.workflows.allops",
       "displayName": "Workflow module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the workflow modules, but no domain permissions",
       "subPermissions": [
-        "workflow.workflow.collection.get",
-        "workflow.workflow.item.get",
-        "workflow.workflow.item.post",
-        "workflow.workflow.item.put",
-        "workflow.workflow.item.patch",
-        "workflow.workflow.item.delete",
-        "workflow.workflow.item.startTrigger",
-        "workflow.workflow.item.activate",
-        "workflow.workflow.item.deactivate",
-        "workflow.workflow.item.tasks"
+        "workflow.workflows.collection.get",
+        "workflow.workflows.item.get",
+        "workflow.workflows.item.post",
+        "workflow.workflows.item.put",
+        "workflow.workflows.item.patch",
+        "workflow.workflows.item.delete",
+        "workflow.workflows.item.startTrigger",
+        "workflow.workflows.item.activate",
+        "workflow.workflows.item.deactivate",
+        "workflow.workflows.item.tasks"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.workflow.all",
+      "permissionName": "workflow.workflows.all",
       "displayName": "Workflow module - all permissions and all workflow domains",
       "description": "Entire set of permissions needed to use the workflow modules on any workflow domain",
       "subPermissions": [
-        "workflow.workflow.allops",
-        "workflow.workflow.domain.all"
+        "workflow.workflows.allops",
+        "workflow.workflows.domain.all"
       ],
       "visible": false
     }

--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -9,8 +9,8 @@
         {
           "methods": ["GET"],
           "pathPattern": "/actions",
-          "permissionsRequired": ["action.collection.get"],
-          "permissionsDesired": ["action.domain.*", "action.domain.all"]
+          "permissionsRequired": ["workflow.action.collection.get"],
+          "permissionsDesired": ["workflow.action.domain.*", "workflow.action.domain.all"]
         }
       ]
     },
@@ -21,14 +21,14 @@
         {
           "methods": ["GET"],
           "pathPattern": "/events/*",
-          "permissionsRequired": ["event.collection.get"],
-          "permissionsDesired": ["event.domain.*", "event.domain.all"]
+          "permissionsRequired": ["workflow.event.collection.get"],
+          "permissionsDesired": ["workflow.event.domain.*", "workflow.event.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/events/*",
-          "permissionsRequired": ["event.collection.post"],
-          "permissionsDesired": ["event.domain.*", "event.domain.all"]
+          "permissionsRequired": ["workflow.event.collection.post"],
+          "permissionsDesired": ["workflow.event.domain.*", "workflow.event.domain.all"]
         }
       ]
     },
@@ -39,32 +39,32 @@
         {
           "methods": ["GET"],
           "pathPattern": "/triggers",
-          "permissionsRequired": ["trigger.collection.get"],
-          "permissionsDesired": ["trigger.domain.*", "trigger.domain.all"]
+          "permissionsRequired": ["workflow.trigger.collection.get"],
+          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["trigger.item.get"],
-          "permissionsDesired": ["trigger.domain.*", "trigger.domain.all"]
+          "permissionsRequired": ["workflow.trigger.item.get"],
+          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/triggers",
-          "permissionsRequired": ["trigger.item.post"],
-          "permissionsDesired": ["trigger.domain.*", "trigger.domain.all"]
+          "permissionsRequired": ["workflow.trigger.item.post"],
+          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["trigger.item.put"],
-          "permissionsDesired": ["trigger.domain.*", "trigger.domain.all"]
+          "permissionsRequired": ["workflow.trigger.item.put"],
+          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/triggers/{id}",
-          "permissionsRequired": ["trigger.item.delete"],
-          "permissionsDesired": ["trigger.domain.*", "trigger.domain.all"]
+          "permissionsRequired": ["workflow.trigger.item.delete"],
+          "permissionsDesired": ["workflow.trigger.domain.*", "workflow.trigger.domain.all"]
         }
       ]
     },
@@ -75,32 +75,32 @@
         {
           "methods": ["GET"],
           "pathPattern": "/tasks",
-          "permissionsRequired": ["task.collection.get"],
-          "permissionsDesired": ["task.domain.*", "task.domain.all"]
+          "permissionsRequired": ["workflow.task.collection.get"],
+          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["task.item.get"],
-          "permissionsDesired": ["task.domain.*", "task.domain.all"]
+          "permissionsRequired": ["workflow.task.item.get"],
+          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/tasks",
-          "permissionsRequired": ["task.item.post"],
-          "permissionsDesired": ["task.domain.*", "task.domain.all"]
+          "permissionsRequired": ["workflow.task.item.post"],
+          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["task.item.put"],
-          "permissionsDesired": ["task.domain.*", "task.domain.all"]
+          "permissionsRequired": ["workflow.task.item.put"],
+          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/tasks/{id}",
-          "permissionsRequired": ["task.item.delete"],
-          "permissionsDesired": ["task.domain.*", "task.domain.all"]
+          "permissionsRequired": ["workflow.task.item.delete"],
+          "permissionsDesired": ["workflow.task.domain.*", "workflow.task.domain.all"]
         }
       ]
     },
@@ -111,74 +111,74 @@
         {
           "methods": ["GET"],
           "pathPattern": "/workflows",
-          "permissionsRequired": ["workflow.collection.get"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.collection.get"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.item.get"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.get"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/workflows",
-          "permissionsRequired": ["workflow.item.post"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.post"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.item.put"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.put"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["PATCH"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.item.patch"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.patch"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/workflows/{id}",
-          "permissionsRequired": ["workflow.item.delete"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.delete"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/workflows/{id}/startTrigger",
-          "permissionsRequired": ["workflow.item.startTrigger"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.startTrigger"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/activate",
-          "permissionsRequired": ["workflow.item.activate"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.activate"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}/deactivate",
-          "permissionsRequired": ["workflow.item.deactivate"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.deactivate"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/workflows/{id}/tasks",
-          "permissionsRequired": ["workflow.item.tasks"],
-          "permissionsDesired": ["workflow.domain.*", "workflow.domain.all"]
+          "permissionsRequired": ["workflow.workflow.item.tasks"],
+          "permissionsDesired": ["workflow.workflow.domain.*", "workflow.workflow.domain.all"]
         }
       ]
     },
@@ -218,229 +218,229 @@
   ],
   "permissionSets" : [
     {
-      "permissionName": "action.collection.get",
+      "permissionName": "workflow.action.collection.get",
       "displayName": "Action - get action collection",
       "description": "Get action collection"
     },
     {
-      "permissionName": "action.allops",
+      "permissionName": "workflow.action.allops",
       "displayName": "Action module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the action modules, but no domain permissions",
       "subPermissions": [
-        "action.collection.get"
+        "workflow.action.collection.get"
       ],
       "visible": false
     },
     {
-      "permissionName": "action.all",
+      "permissionName": "workflow.action.all",
       "displayName": "Action module - all permissions and all action domains",
       "description": "Entire set of permissions needed to use the action modules on any action domain",
       "subPermissions": [
-        "action.allops",
-        "action.domain.all"
+        "workflow.action.allops",
+        "workflow.action.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "event.collection.get",
+      "permissionName": "workflow.event.collection.get",
       "displayName": "Event - emit event",
       "description": "Emit event"
     },
     {
-      "permissionName": "event.collection.post",
+      "permissionName": "workflow.event.collection.post",
       "displayName": "Event - emit event",
       "description": "Emit event"
     },
     {
-      "permissionName": "event.allops",
+      "permissionName": "workflow.event.allops",
       "displayName": "Event module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the event modules, but no domain permissions",
       "subPermissions": [
-        "event.collection.get"
+        "workflow.event.collection.get"
       ],
       "visible": false
     },
     {
-      "permissionName": "event.all",
+      "permissionName": "workflow.event.all",
       "displayName": "Event module - all permissions and all event domains",
       "description": "Entire set of permissions needed to use the event modules on any event domain",
       "subPermissions": [
-        "event.allops",
-        "event.domain.all"
+        "workflow.event.allops",
+        "workflow.event.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "trigger.collection.get",
+      "permissionName": "workflow.trigger.collection.get",
       "displayName": "Trigger - get trigger collection",
       "description": "Get trigger collection"
     },
     {
-      "permissionName": "trigger.item.get",
+      "permissionName": "workflow.trigger.item.get",
       "displayName": "Trigger - get trigger item",
       "description": "Get trigger item"
     },
     {
-      "permissionName": "trigger.item.post",
+      "permissionName": "workflow.trigger.item.post",
       "displayName": "Trigger - post trigger item",
       "description": "Create trigger item"
     },
     {
-      "permissionName": "trigger.item.put",
+      "permissionName": "workflow.trigger.item.put",
       "displayName": "Trigger - put trigger item",
       "description": "Update trigger item"
     },
     {
-      "permissionName": "trigger.item.delete",
+      "permissionName": "workflow.trigger.item.delete",
       "displayName": "Trigger - delete trigger item",
       "description": "Delete trigger item"
     },
     {
-      "permissionName": "trigger.allops",
+      "permissionName": "workflow.trigger.allops",
       "displayName": "Trigger module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the trigger modules, but no domain permissions",
       "subPermissions": [
-        "trigger.collection.get",
-        "trigger.item.get",
-        "trigger.item.post",
-        "trigger.item.put",
-        "trigger.item.delete"
+        "workflow.trigger.collection.get",
+        "workflow.trigger.item.get",
+        "workflow.trigger.item.post",
+        "workflow.trigger.item.put",
+        "workflow.trigger.item.delete"
       ],
       "visible": false
     },
     {
-      "permissionName": "trigger.all",
+      "permissionName": "workflow.trigger.all",
       "displayName": "Trigger module - all permissions and all trigger domains",
       "description": "Entire set of permissions needed to use the trigger modules on any trigger domain",
       "subPermissions": [
-        "trigger.allops",
-        "trigger.domain.all"
+        "workflow.trigger.allops",
+        "workflow.trigger.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "task.collection.get",
+      "permissionName": "workflow.task.collection.get",
       "displayName": "Task - get task collection",
       "description": "Get task collection"
     },
     {
-      "permissionName": "task.item.get",
+      "permissionName": "workflow.task.item.get",
       "displayName": "Task - get task item",
       "description": "Get task item"
     },
     {
-      "permissionName": "task.item.post",
+      "permissionName": "workflow.task.item.post",
       "displayName": "Task - post task item",
       "description": "Create task item"
     },
     {
-      "permissionName": "task.item.put",
+      "permissionName": "workflow.task.item.put",
       "displayName": "Task - put task item",
       "description": "Update task item"
     },
     {
-      "permissionName": "task.item.delete",
+      "permissionName": "workflow.task.item.delete",
       "displayName": "Task - delete task item",
       "description": "Delete task item"
     },
     {
-      "permissionName": "task.allops",
+      "permissionName": "workflow.task.allops",
       "displayName": "Task module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the task modules, but no domain permissions",
       "subPermissions": [
-        "task.collection.get",
-        "task.item.get",
-        "task.item.post",
-        "task.item.put",
-        "task.item.delete"
+        "workflow.task.collection.get",
+        "workflow.task.item.get",
+        "workflow.task.item.post",
+        "workflow.task.item.put",
+        "workflow.task.item.delete"
       ],
       "visible": false
     },
     {
-      "permissionName": "task.all",
+      "permissionName": "workflow.task.all",
       "displayName": "Task module - all permissions and all task domains",
       "description": "Entire set of permissions needed to use the task modules on any task domain",
       "subPermissions": [
-        "task.allops",
-        "task.domain.all"
+        "workflow.task.allops",
+        "workflow.task.domain.all"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.collection.get",
+      "permissionName": "workflow.workflow.collection.get",
       "displayName": "Workflow - get workflow collection",
       "description": "Get workflow collection"
     },
     {
-      "permissionName": "workflow.item.get",
+      "permissionName": "workflow.workflow.item.get",
       "displayName": "Workflow - get workflow item",
       "description": "Get workflow item"
     },
     {
-      "permissionName": "workflow.item.post",
+      "permissionName": "workflow.workflow.item.post",
       "displayName": "Workflow - post workflow item",
       "description": "Create workflow item"
     },
     {
-      "permissionName": "workflow.item.put",
+      "permissionName": "workflow.workflow.item.put",
       "displayName": "Workflow - put workflow item",
       "description": "Update workflow item"
     },
     {
-      "permissionName": "workflow.item.patch",
+      "permissionName": "workflow.workflow.item.patch",
       "displayName": "Workflow - patch workflow item",
       "description": "Patch workflow item"
     },
     {
-      "permissionName": "workflow.item.delete",
+      "permissionName": "workflow.workflow.item.delete",
       "displayName": "Workflow - delete workflow item",
       "description": "Delete workflow item"
     },
     {
-      "permissionName": "workflow.item.startTrigger",
+      "permissionName": "workflow.workflow.item.startTrigger",
       "displayName": "Workflow - add/remove start trigger on workflow item",
       "description": "Add/remove start trigger on workflow item"
     },
     {
-      "permissionName": "workflow.item.activate",
+      "permissionName": "workflow.workflow.item.activate",
       "displayName": "Workflow - activate workflow item",
       "description": "Activate workflow item"
     },
     {
-      "permissionName": "workflow.item.deactivate",
+      "permissionName": "workflow.workflow.item.deactivate",
       "displayName": "Workflow - deactivate workflow item",
       "description": "Dactivate workflow item"
     },
     {
-      "permissionName": "workflow.item.tasks",
+      "permissionName": "workflow.workflow.item.tasks",
       "displayName": "Workflow - workflow item tasks",
       "description": "Get workflow item tasks"
     },
     {
-      "permissionName": "workflow.allops",
+      "permissionName": "workflow.workflow.allops",
       "displayName": "Workflow module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the workflow modules, but no domain permissions",
       "subPermissions": [
-        "workflow.collection.get",
-        "workflow.item.get",
-        "workflow.item.post",
-        "workflow.item.put",
-        "workflow.item.patch",
-        "workflow.item.delete",
-        "workflow.item.startTrigger",
-        "workflow.item.activate",
-        "workflow.item.deactivate",
-        "workflow.item.tasks"
+        "workflow.workflow.collection.get",
+        "workflow.workflow.item.get",
+        "workflow.workflow.item.post",
+        "workflow.workflow.item.put",
+        "workflow.workflow.item.patch",
+        "workflow.workflow.item.delete",
+        "workflow.workflow.item.startTrigger",
+        "workflow.workflow.item.activate",
+        "workflow.workflow.item.deactivate",
+        "workflow.workflow.item.tasks"
       ],
       "visible": false
     },
     {
-      "permissionName": "workflow.all",
+      "permissionName": "workflow.workflow.all",
       "displayName": "Workflow module - all permissions and all workflow domains",
       "description": "Entire set of permissions needed to use the workflow modules on any workflow domain",
       "subPermissions": [
-        "workflow.allops",
-        "workflow.domain.all"
+        "workflow.workflow.allops",
+        "workflow.workflow.domain.all"
       ],
       "visible": false
     }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ logging:
 
 server:
   servlet:
-    context-path: /mod-workflow
+    context-path: /
   port: 9001
 
 spring:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -74,8 +74,8 @@ tenant:
 okapi:
   url: ${OKAPI_URL:http://localhost:9130}
   camunda:
-    base-path: /mod-camunda
-    rest-path: /mod-camunda/rest
+    base-path: /
+    rest-path: /rest
 
 management:
   endpoints:


### PR DESCRIPTION
resolves #113

### Changes
Prepend 'camunda.' to each permission.
- This gets the permissions structure to be compliant by having the module name as part of the permission name.
- Without this, potential cross-module conflicts exist.

The `provides` dependencies are for individual module parts and not the entire module.
Change the behavior to use the individual mod-workflow parts as a dependency.

Remove `mod-camunda` from the context path.
Having `mod-camunda` in the context path is preventing proper deployment in OKAPI.

### Local Deployment Test Process
This assumes proper login and other relating configuration.
This uses `{{}}` syntax to loosely represent variables.
Consider using the [stripes-cli](https://github.com/folio-org/stripes-cli/) to perform the appropriate tasks.

1. Make sure to start up a local docker or vagrant version of folio, like the [FOLIO Nolana vagrant](https://app.vagrantup.com/folio/boxes/release/versions/1.0.0-20230320.7993).
For example, the OKAPI login using stripes-cli might look like this:
```shell
stripes okapi login diku_admin --okapi http://127.0.0.1:9130 --tenant diku
```
2. Perform the appropriate maven packaging of the project.
3. Spin up a local instance of mod-workflow, such as `mvn spring-boot:run`, `java -jar ...`, or an appropriate docker command.
4. A **POST** request to `{{okapi_url}}/_/proxy/modules` in order to register the module.
Make sure to use the build `ModuleDescriptor.json` as the payload body, generally found under `service/target/`.
5. A **POST** request to `{{okapi_url}}/_/discovery/modules`.
Rather than using the `DeploymentDescriptor.json` generally found under `service/target/`, use the following as the payload body.
```json
{
  "srvcId": "mod-workflow-{{mod_workflow_version}}",
  "instId": "mod-workflow-{{mod_workflow_version}}",
  "url": "{{mod_workflow_url}}"
}
```
The `{{mod_workflow_url}}` in particular needs to point to an address of the locally running mod-workflow that the local FOLIO instance can access.
6. A **POST** request to `{{okapi_url}}/_/proxy/tenants/{{tenant_name}}/modules`, using the following as the body payload:
```json
{
  "id": "mod-workflow-{{mod_workflow_version}}"
}
```

There may be permissions problems, in which case, they could be resolved using the stripes-cli. Example:
```shell
echo "okapi.proxy.modules.post" | stripes perm assign --okapi http://127.0.0.1:9130 --user diku_admin --tenant diku
```

To disable the module, a **DELETE** to `{{okapi_url}}/_/proxy/tenants/{{tenant_name}}/modules/mod-workflow-{{mod_workflow_version}}`.

To undeploy the module, a **DELETE** to `{{okapi_url}}/_/discovery/modules/mod-workflow-{{mod_workflow_version}}`.
