### PR TITLE
Null check headers

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -275,8 +275,12 @@ public class WorkflowEngineService {
 
   private HttpHeaders headers(String tenant, String token) {
     HttpHeaders requestHeaders = new HttpHeaders();
-    requestHeaders.add(tenantHeaderName, tenant);
-    requestHeaders.add(tokenHeaderName, token);
+    if (tenant != null) {
+      requestHeaders.add(tenantHeaderName, tenant);
+    }
+    if (token != null) {
+      requestHeaders.add(tokenHeaderName, token);
+    }
     requestHeaders.add("Content-Type", "application/json");
     return requestHeaders;
   }


### PR DESCRIPTION
```
workflow     | 15:26:57 [] [tamu] [] [mod-workflow] INFO  orkflowEngineService FETCHING DEPLOYMENT DEFINITION: 90bd8ad7-8004-11ef-88f9-0242ac140006 1.0 tamu null
workflow     | 15:26:57 [] [tamu] [] [mod-workflow] INFO  orkflowEngineService URL: http://camunda:8081/rest/process-definition?deploymentId=90bd8ad7-8004-11ef-88f9-0242ac140006&versionTag=1.0&maxResults=1
workflow     | 15:26:57 [] [tamu] [] [mod-workflow] DEBUG flowControllerAdvice Failed to deployment definition: Parameter specified as non-null is null: method okhttp3.Request$Builder.addHeader, parameter value! http://camunda:8081/rest/process-definition?deploymentId=90bd8ad7-8004-11ef-88f9-0242ac140006&versionTag=1.0&maxResults=1
workflow     | org.folio.rest.workflow.exception.WorkflowEngineServiceException: Failed to deployment definition: Parameter specified as non-null is null: method okhttp3.Request$Builder.addHeader, parameter value! http://camunda:8081/rest/process-definition?deploymentId=90bd8ad7-8004-11ef-88f9-0242ac140006&versionTag=1.0&maxResults=1
```