### PR TITLE
MODWRKFLOW-66: Utilize relatively new Docker feature to change mode on COPY.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV VERTICLE_FILE workflow-service.jar
 ENV VERTICLE_HOME /usr/verticles
 
 # Copy your jar to the container.
-COPY service/target/workflow-service*.jar ${VERTICLE_HOME}/${VERTICLE_FILE}
+COPY --chmod=644 service/target/workflow-service*.jar ${VERTICLE_HOME}/${VERTICLE_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 8081


### PR DESCRIPTION
This is a back port of the docker changes from upstream MODWRKFLOW-66.

This avoids relying on user space within the container to explicitly run `chmod`. This reduces the security burden if/when a `chmod` has some exploit and needs updating.

This also reduces the extra duplication that Docker creates for every change. A separate `RUN chmod` command would result in a duplication of the entire JAR file and possibly other files within the image. Using `COPY --chmod=` avoids this.

Be warned that this is a new feature and older **Docker** clients may have problems building this.