### PR TITLE
Issue 158: Ensure Java time stamps work.

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.persistence.AttributeConverter;
 
 /**
@@ -16,9 +18,11 @@ public abstract class AbstractConverter<T> implements AttributeConverter<T, Stri
 
   private ObjectMapper objectMapper = JsonMapper.builder()
     .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+    .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
     .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .addModule(new JavaTimeModule())
     .build();
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>spring-module-core</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>mod-workflow</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -105,6 +105,11 @@
        <artifactId>commons-compress</artifactId>
        <version>1.28.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
   </dependencies>
 
   <pluginRepositories>

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.jknack.handlebars.internal.Files;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -79,6 +80,8 @@ public class WorkflowImportService {
     this.nodeRepo = nodeRepo;
     this.triggerRepo = triggerRepo;
     this.workflowRepo = workflowRepo;
+
+    this.objectMapper.registerModule(new JavaTimeModule());
   }
 
   /**

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -19,11 +19,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
 import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
@@ -73,7 +78,15 @@ class WorkflowEngineServiceTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = new JsonMapper();
+    mapper = JsonMapper.builder()
+      .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+      .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+      .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+      .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .addModule(new JavaTimeModule())
+      .build();
+
     workflowEngineService = new WorkflowEngineService(workflowRepo, mapper, new RestTemplateBuilder());
 
     workflow = new WorkflowAsDto();

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
@@ -5,12 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
-import org.apache.commons.compress.archivers.ArchiveException;
-import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowImportInvalidOrMissingProperty;
@@ -22,7 +26,6 @@ import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,8 +34,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK)
 @ExtendWith(MockitoExtension.class)
@@ -41,20 +42,14 @@ class WorkflowImportServiceTest {
 
   private static final String WORKFLOW_UUID = "7dcd302f-a438-4ca5-a7eb-21653610d46f";
 
-  @InjectMocks
-  private WorkflowImportService workflowImportService;
-
-  @MockitoBean
+  @Mock
   private NodeRepo nodeRepo;
 
-  @MockitoBean
+  @Mock
   private TriggerRepo triggerRepo;
 
-  @MockitoBean
+  @Mock
   private WorkflowRepo workflowRepo;
-
-  @MockitoSpyBean
-  private ObjectMapper objectMapper;
 
   @Mock
   private Page<Workflow> page;
@@ -140,14 +135,29 @@ class WorkflowImportServiceTest {
   @Value("classpath:fwz/unit_test_zip.fwz")
   private Resource fwzZipResource;
 
+  private JsonMapper mapper;
+
   private Workflow workflow;
+
+  private WorkflowImportService workflowImportService;
 
   @BeforeEach
   void beforeEach() {
+    mapper = JsonMapper.builder()
+      .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+      .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+      .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+      .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .addModule(new JavaTimeModule())
+      .build();
+
     workflow = new Workflow();
     workflow.setId(WORKFLOW_UUID);
 
-    when(workflowRepo.save(any())).thenReturn(workflow);
+    workflowImportService = new WorkflowImportService(mapper, nodeRepo, triggerRepo, workflowRepo);
+
+    lenient().when(workflowRepo.save(any())).thenReturn(workflow);
   }
 
   @Test
@@ -252,91 +262,91 @@ class WorkflowImportServiceTest {
   }
 
   @Test
-  void importFileWorksForBzip2Test() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForBzip2Test() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzBzip2Resource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForBzip2AsBz2Test() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForBzip2AsBz2Test() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzBzip2AsBz2Resource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipAsGzTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipAsGzTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipAsGzResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithBadVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithBadVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipBadVersionResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithJavaTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithJavaTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipJavaResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithOddFilesTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithOddFilesTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipOddFilesResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithPythonTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithPythonTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipPythonResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithRubyTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithRubyTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipRubyResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithMissingVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithMissingVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipMisVersionResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithUnknownVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithUnknownVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipUnVerResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForZipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForZipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzZipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForZipAsZipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForZipAsZipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzZipAsZipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());


### PR DESCRIPTION
Resolves #158.

Explicitly bring in `jackson-datatype-jsr310`.

Add `JavaTimeModule`.

Explicitly ensure `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` is enabled.

Switch to `2.1.1-SNAPSHOT` branch that contains the relating changes from that repository.workflowRepo

Fix unit test that broke with these changes.
Simplify the design to avoid the Junit/Mockito and use more direct behaviors. Such designs seem more stable and easier to maintain.