### PR TITLE
Issue 161: Back Port MODWRKFLOW-70: Implement sendEmptyBody support.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/dto/Request.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/Request.java
@@ -30,12 +30,17 @@ public class Request {
 
   private String responseKey;
 
+  @NotNull
+  private Boolean sendEmptyBody;
+
   public Request() {
     super();
-    contentType = MediaType.APPLICATION_JSON_VALUE;
+
     accept = MediaType.APPLICATION_JSON_VALUE;
-    bodyTemplate = "{}";
+    contentType = MediaType.APPLICATION_JSON_VALUE;
+    bodyTemplate = null;
     iterable = false;
+    sendEmptyBody = true;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
@@ -68,6 +68,16 @@ public abstract class AbstractTask extends Node implements HasInputOutput, Task 
 
     if (inputVariables == null) {
       inputVariables = new HashSet<>();
+    } else {
+      // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+      inputVariables.forEach((EmbeddedVariable ev) -> {
+        if (ev != null) ev.prePersist();
+      });
+    }
+
+    // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+    if (outputVariable != null) {
+      outputVariable.prePersist();
     }
   }
 

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
@@ -6,65 +6,56 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.HttpMethod;
+import org.folio.rest.workflow.model.has.HasUrl;
 import org.folio.rest.workflow.model.has.common.HasEmbeddedRequestCommon;
 import org.springframework.http.MediaType;
 
 @Embeddable
-public class EmbeddedRequest implements HasEmbeddedRequestCommon {
+public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
 
-  @Getter
-  @Setter
+  // Must be designated as nullable even if this is not supposed to be NULL.
   @NotNull
-  @Column(nullable = false)
+  @Column(nullable = true)
   private String accept;
 
-  @Getter
-  @Setter
-  @Column(columnDefinition = "TEXT", nullable = false)
+  @Column(columnDefinition = "TEXT", nullable = true)
   private String bodyTemplate;
 
-  @Getter
-  @Setter
+  // Must be designated as nullable even if this is not supposed to be NULL.
   @NotNull
-  @Column(nullable = false)
+  @Column(nullable = true)
   private String contentType;
 
-  @Getter
-  @Setter
   private boolean iterable;
 
-  @Getter
-  @Setter
   private String iterableKey;
 
-  @Getter
-  @Setter
+  // Must be designated as nullable even if this is not supposed to be NULL.
   @NotNull
-  @Column(nullable = false)
+  @Column(nullable = true)
   @Enumerated(EnumType.STRING)
   private HttpMethod method;
 
-  @Getter
-  @Setter
   private String responseKey;
 
-  @Getter
-  @Setter
-  @NotNull
   @Column(nullable = false)
+  private Boolean sendEmptyBody;
+
+  // Must be designated as nullable even if this is not supposed to be NULL.
+  @NotNull
+  @Column(nullable = true)
   private String url;
 
   public EmbeddedRequest() {
     super();
 
     accept = MediaType.APPLICATION_JSON_VALUE;
-    bodyTemplate = "{}";
+    bodyTemplate = null;
     contentType = MediaType.APPLICATION_JSON_VALUE;
     iterable = false;
     method = HttpMethod.GET;
+    sendEmptyBody = true;
     url = "";
   }
 
@@ -74,8 +65,12 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon {
       accept = MediaType.APPLICATION_JSON_VALUE;
     }
 
-    if (bodyTemplate == null) {
-      bodyTemplate = "{}";
+    if (sendEmptyBody == null) {
+      sendEmptyBody = true;
+    }
+
+    if (bodyTemplate == null || bodyTemplate.isEmpty()) {
+      bodyTemplate = Boolean.TRUE.equals(sendEmptyBody) ? "{}" : null;
     }
 
     if (contentType == null) {
@@ -89,6 +84,96 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon {
     if (url == null) {
       url = "";
     }
+  }
+
+  @Override
+  public String getAccept() {
+    return accept;
+  }
+
+  @Override
+  public String getBodyTemplate() {
+    return bodyTemplate;
+  }
+
+  @Override
+  public String getContentType() {
+    return contentType;
+  }
+
+  @Override
+  public boolean isIterable() {
+    return iterable;
+  }
+
+  @Override
+  public String getIterableKey() {
+    return iterableKey;
+  }
+
+  @Override
+  public Boolean getSendEmptyBody() {
+    return sendEmptyBody;
+  }
+
+  @Override
+  public void setAccept(String accept) {
+    this.accept = accept;
+  }
+
+  @Override
+  public void setBodyTemplate(String bodyTemplate) {
+    this.bodyTemplate = bodyTemplate;
+  }
+
+  @Override
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  @Override
+  public void setIterable(boolean iterable) {
+    this.iterable = iterable;
+  }
+
+  @Override
+  public void setIterableKey(String iterableKey) {
+    this.iterableKey = iterableKey;
+  }
+
+  @Override
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  @Override
+  public String getResponseKey() {
+    return responseKey;
+  }
+
+  @Override
+  public void setMethod(HttpMethod method) {
+    this.method = method;
+  }
+
+  @Override
+  public void setResponseKey(String responseKey) {
+    this.responseKey = responseKey;
+  }
+
+  @Override
+  public String getUrl() {
+    return url;
+  }
+
+  @Override
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public void setSendEmptyBody(Boolean sendEmptyBody) {
+    this.sendEmptyBody = sendEmptyBody;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
@@ -29,6 +29,11 @@ public class InputTask extends AbstractTask {
 
     if (inputs == null) {
       inputs = new HashSet<>();
+    } else {
+      // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+      inputs.forEach((EmbeddedInput ei) -> {
+        if (ei != null) ei.prePersist();
+      });
     }
   }
 

--- a/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
@@ -17,6 +17,11 @@ public class ProcessorTask extends AbstractTask implements DelegateTask, HasProc
 
   public ProcessorTask() {
     super();
+
+    // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+    if (processor != null) {
+      processor.prePersist();
+    }
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
@@ -3,6 +3,7 @@ package org.folio.rest.workflow.model;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrePersist;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
@@ -28,5 +29,21 @@ public class RequestTask extends AbstractTask implements DelegateTask, HasReques
 
     headerOutputVariables = new HashSet<>();
   }
+
+  @Override
+  @PrePersist
+  public void prePersist() {
+    super.prePersist();
+
+    if (headerOutputVariables == null) {
+      headerOutputVariables = new HashSet<>();
+    } else {
+      // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+      headerOutputVariables.forEach((EmbeddedVariable ev) -> {
+        if (ev != null) ev.prePersist();
+      });
+    }
+  }
+
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
@@ -42,6 +42,11 @@ public class Subprocess extends AbstractProcess implements Branch, MultiInstance
     if (type == null) {
       type = SubprocessType.EMBEDDED;
     }
+
+    // @Embeddable with @PrePersist do not consistently call PrePersist and so this must be manually triggered.
+    if (loopRef != null) {
+      loopRef.prePersist();
+    }
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
@@ -12,7 +12,8 @@ public interface HasEmbeddedRequestCommon {
   public String getContentType();
   public String getIterableKey();
   public HttpMethod getMethod();
-  public String getResponseKey() ;
+  public String getResponseKey();
+  public Boolean getSendEmptyBody();
   public boolean isIterable();
 
   public void setAccept(String accept);
@@ -22,5 +23,6 @@ public interface HasEmbeddedRequestCommon {
   public void setIterableKey(String iterableKey);
   public void setMethod(HttpMethod method);
   public void setResponseKey(String responseKey);
+  public void setSendEmptyBody(Boolean sendEmptyBody);
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/dto/RequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/dto/RequestTest.java
@@ -11,6 +11,15 @@ import org.springframework.http.HttpMethod;
 
 class RequestTest {
 
+  private static final String ACCEPT        = "accept";
+  private static final String BODYTEMPLATE  = "bodyTemplate";
+  private static final String CONTENTTYPE   = "contentType";
+  private static final String ITERABLE      = "iterable";
+  private static final String METHOD        = "method";
+  private static final String RESPONSEKEY   = "responseKey";
+  private static final String SENDEMPTYBODY = "sendEmptyBody";
+  private static final String URL           = "url";
+
   private Request request;
 
   @BeforeEach
@@ -20,109 +29,128 @@ class RequestTest {
 
   @Test
   void getUrlWorksTest() {
-    setField(request, "url", VALUE);
+    setField(request, URL, VALUE);
 
     assertEquals(VALUE, request.getUrl());
   }
 
   @Test
   void setUrlWorksTest() {
-    setField(request, "url", null);
+    setField(request, URL, null);
 
     request.setUrl(VALUE);
-    assertEquals(VALUE, getField(request, "url"));
+    assertEquals(VALUE, getField(request, URL));
   }
 
   @Test
   void getMethodWorksTest() {
-    setField(request, "method", HttpMethod.DELETE);
+    setField(request, METHOD, HttpMethod.DELETE);
 
     assertEquals(HttpMethod.DELETE, request.getMethod());
   }
 
   @Test
   void setMethodWorksTest() {
-    setField(request, "method", null);
+    setField(request, METHOD, null);
 
     request.setMethod(HttpMethod.DELETE);
-    assertEquals(HttpMethod.DELETE, getField(request, "method"));
+    assertEquals(HttpMethod.DELETE, getField(request, METHOD));
   }
 
   @Test
   void getContentTypeWorksTest() {
-    setField(request, "contentType", VALUE);
+    setField(request, CONTENTTYPE, VALUE);
 
     assertEquals(VALUE, request.getContentType());
   }
 
   @Test
   void setContentTypeWorksTest() {
-    setField(request, "contentType", null);
+    setField(request, CONTENTTYPE, null);
 
     request.setContentType(VALUE);
-    assertEquals(VALUE, getField(request, "contentType"));
+    assertEquals(VALUE, getField(request, CONTENTTYPE));
   }
 
   @Test
   void getAcceptWorksTest() {
-    setField(request, "accept", VALUE);
+    setField(request, ACCEPT, VALUE);
 
     assertEquals(VALUE, request.getAccept());
   }
 
   @Test
   void setAcceptWorksTest() {
-    setField(request, "accept", null);
+    setField(request, ACCEPT, null);
 
     request.setAccept(VALUE);
-    assertEquals(VALUE, getField(request, "accept"));
+    assertEquals(VALUE, getField(request, ACCEPT));
   }
 
   @Test
   void getBodyTemplateWorksTest() {
-    setField(request, "bodyTemplate", VALUE);
+    setField(request, BODYTEMPLATE, VALUE);
 
     assertEquals(VALUE, request.getBodyTemplate());
   }
 
   @Test
   void setBodyTemplateWorksTest() {
-    setField(request, "bodyTemplate", null);
+    setField(request, BODYTEMPLATE, null);
 
     request.setBodyTemplate(VALUE);
-    assertEquals(VALUE, getField(request, "bodyTemplate"));
+    assertEquals(VALUE, getField(request, BODYTEMPLATE));
   }
 
   @Test
   void getIterableWorksTest() {
-    setField(request, "iterable", true);
+    setField(request, ITERABLE, true);
 
     assertEquals(true, request.isIterable());
   }
 
   @Test
   void setIterableWorksTest() {
-    setField(request, "iterable", false);
+    setField(request, ITERABLE, false);
 
     request.setIterable(true);
-    assertEquals(true, getField(request, "iterable"));
+    assertEquals(true, getField(request, ITERABLE));
   }
 
   @Test
   void getResponseKeyWorksTest() {
-    setField(request, "responseKey", VALUE);
+    setField(request, RESPONSEKEY, VALUE);
 
     assertEquals(VALUE, request.getResponseKey());
   }
 
   @Test
   void setResponseKeyWorksTest() {
-    setField(request, "responseKey", null);
+    setField(request, RESPONSEKEY, null);
 
     request.setResponseKey(VALUE);
-    assertEquals(VALUE, getField(request, "responseKey"));
+    assertEquals(VALUE, getField(request, RESPONSEKEY));
   }
 
-  private static class Impl extends Request { };
+  @Test
+  void getSendEmptyBodyWorksTest() {
+    final boolean value = false;
+
+    setField(request, SENDEMPTYBODY, value);
+
+    assertEquals(value, request.getSendEmptyBody());
+  }
+
+  @Test
+  void setSendEmptyBodyWorksTest() {
+    final boolean value = true;
+
+    setField(request, SENDEMPTYBODY, null);
+
+    request.setSendEmptyBody(value);
+    assertEquals(value, getField(request, SENDEMPTYBODY));
+  }
+
+  private static class Impl extends Request { }
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
@@ -12,9 +12,9 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import org.folio.rest.workflow.enums.HttpMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +23,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class EmbeddedRequestTest {
+
+  private static final String ACCEPT        = "accept";
+  private static final String BODYTEMPLATE  = "bodyTemplate";
+  private static final String CONTENTTYPE   = "contentType";
+  private static final String ITERABLE      = "iterable";
+  private static final String ITERABLEKEY   = "iterableKey";
+  private static final String METHOD        = "method";
+  private static final String RESPONSEKEY   = "responseKey";
+  private static final String SENDEMPTYBODY = "sendEmptyBody";
+  private static final String URL           = "url";
 
   private EmbeddedRequest embeddedRequest;
 
@@ -33,107 +43,141 @@ class EmbeddedRequestTest {
 
   @Test
   void getUrlWorksTest() {
-    setField(embeddedRequest, "url", VALUE);
+    setField(embeddedRequest, URL, VALUE);
 
     assertEquals(VALUE, embeddedRequest.getUrl());
   }
 
   @Test
   void setUrlWorksTest() {
-    setField(embeddedRequest, "url", null);
+    setField(embeddedRequest, URL, null);
 
     embeddedRequest.setUrl(VALUE);
-    assertEquals(VALUE, getField(embeddedRequest, "url"));
+    assertEquals(VALUE, getField(embeddedRequest, URL));
   }
 
   @Test
   void getMethodWorksTest() {
-    setField(embeddedRequest, "method", DELETE);
+    setField(embeddedRequest, METHOD, DELETE);
 
     assertEquals(DELETE, embeddedRequest.getMethod());
   }
 
   @Test
   void setMethodWorksTest() {
-    setField(embeddedRequest, "method", null);
+    setField(embeddedRequest, METHOD, null);
 
     embeddedRequest.setMethod(DELETE);
-    assertEquals(DELETE, getField(embeddedRequest, "method"));
+    assertEquals(DELETE, getField(embeddedRequest, METHOD));
   }
 
   @Test
   void getContentTypeWorksTest() {
-    setField(embeddedRequest, "contentType", VALUE);
+    setField(embeddedRequest, CONTENTTYPE, VALUE);
 
     assertEquals(VALUE, embeddedRequest.getContentType());
   }
 
   @Test
   void setContentTypeWorksTest() {
-    setField(embeddedRequest, "contentType", null);
+    setField(embeddedRequest, CONTENTTYPE, null);
 
     embeddedRequest.setContentType(VALUE);
-    assertEquals(VALUE, getField(embeddedRequest, "contentType"));
+    assertEquals(VALUE, getField(embeddedRequest, CONTENTTYPE));
   }
 
   @Test
   void getAcceptWorksTest() {
-    setField(embeddedRequest, "accept", VALUE);
+    setField(embeddedRequest, ACCEPT, VALUE);
 
     assertEquals(VALUE, embeddedRequest.getAccept());
   }
 
   @Test
   void setAcceptWorksTest() {
-    setField(embeddedRequest, "accept", null);
+    setField(embeddedRequest, ACCEPT, null);
 
     embeddedRequest.setAccept(VALUE);
-    assertEquals(VALUE, getField(embeddedRequest, "accept"));
+    assertEquals(VALUE, getField(embeddedRequest, ACCEPT));
   }
 
   @Test
   void getBodyTemplateWorksTest() {
-    setField(embeddedRequest, "bodyTemplate", VALUE);
+    setField(embeddedRequest, BODYTEMPLATE, VALUE);
 
     assertEquals(VALUE, embeddedRequest.getBodyTemplate());
   }
 
   @Test
   void setBodyTemplateWorksTest() {
-    setField(embeddedRequest, "bodyTemplate", null);
+    setField(embeddedRequest, BODYTEMPLATE, null);
 
     embeddedRequest.setBodyTemplate(VALUE);
-    assertEquals(VALUE, getField(embeddedRequest, "bodyTemplate"));
+    assertEquals(VALUE, getField(embeddedRequest, BODYTEMPLATE));
   }
 
   @Test
-  void getIterableWorksTest() {
-    setField(embeddedRequest, "iterable", true);
+  void isIterableWorksTest() {
+    setField(embeddedRequest, ITERABLE, true);
 
     assertEquals(true, embeddedRequest.isIterable());
   }
 
   @Test
   void setIterableWorksTest() {
-    setField(embeddedRequest, "iterable", false);
+    setField(embeddedRequest, ITERABLE, false);
 
     embeddedRequest.setIterable(true);
-    assertEquals(true, getField(embeddedRequest, "iterable"));
+    assertEquals(true, getField(embeddedRequest, ITERABLE));
+  }
+
+  @Test
+  void getIterableKeyWorksTest() {
+    setField(embeddedRequest, ITERABLEKEY, VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getIterableKey());
+  }
+
+  @Test
+  void setIterableKeyWorksTest() {
+    setField(embeddedRequest, ITERABLEKEY, null);
+
+    embeddedRequest.setIterableKey(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, ITERABLEKEY));
   }
 
   @Test
   void getResponseKeyWorksTest() {
-    setField(embeddedRequest, "responseKey", VALUE);
+    setField(embeddedRequest, RESPONSEKEY, VALUE);
 
     assertEquals(VALUE, embeddedRequest.getResponseKey());
   }
 
   @Test
   void setResponseKeyWorksTest() {
-    setField(embeddedRequest, "responseKey", null);
+    setField(embeddedRequest, RESPONSEKEY, null);
 
     embeddedRequest.setResponseKey(VALUE);
-    assertEquals(VALUE, getField(embeddedRequest, "responseKey"));
+    assertEquals(VALUE, getField(embeddedRequest, RESPONSEKEY));
+  }
+
+  @Test
+  void getSendEmptyBodyWorksTest() {
+    final boolean value = false;
+
+    setField(embeddedRequest, SENDEMPTYBODY, value);
+
+    assertEquals(value, embeddedRequest.getSendEmptyBody());
+  }
+
+  @Test
+  void setSendEmptyBodyWorksTest() {
+    final boolean value = true;
+
+    setField(embeddedRequest, SENDEMPTYBODY, null);
+
+    embeddedRequest.setSendEmptyBody(value);
+    assertEquals(value, getField(embeddedRequest, SENDEMPTYBODY));
   }
 
   @ParameterizedTest
@@ -160,53 +204,59 @@ class EmbeddedRequestTest {
    */
   private static Stream<Arguments> providePrePersistFor() {
 
-    return Stream.of(
+    return List.of(
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  "")
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(VALUE,    NULL_STR,    NULL_STR, null, NULL_STR),
-        helperFieldMap(VALUE,    JSON_OBJECT, APP_JSON, GET,  "")
+        helperFieldMap(VALUE,    NULL_STR,    NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(VALUE,    JSON_OBJECT, APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, VALUE,       NULL_STR, null, NULL_STR),
-        helperFieldMap(APP_JSON, VALUE,       APP_JSON, GET,  "")
+        helperFieldMap(NULL_STR, VALUE,       NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, VALUE,       APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    VALUE,    null, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, VALUE,    GET,  "")
+        helperFieldMap(NULL_STR, NULL_STR,    VALUE,    null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, VALUE,    GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, POST, "")
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, POST, true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, VALUE),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  VALUE)
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, false, NULL_STR),
+        helperFieldMap(APP_JSON, NULL_STR,    APP_JSON, POST, false, "")
+      ),
+      Arguments.of(
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, null,  VALUE),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  true,  VALUE)
       )
-    );
+    ).stream();
   }
 
   /**
-   * Helper for reducing inline code repititon for assignments.
+   * Helper for reducing in line code repetition for assignments.
    *
-   * @param accept The accept value.
-   * @param bodyTemplate The bodyTemplate value.
-   * @param contentType The contentType value.
-   * @param method The method value.
-   * @param url The url value.
+   * @param accept        The accept value.
+   * @param bodyTemplate  The bodyTemplate value.
+   * @param contentType   The contentType value.
+   * @param method        The method value.
+   * @param sendEmptyBody The sendEmptyBody value.
+   * @param url           The url value.
    *
    * @return The built arguments map.
    */
-  private static Map<String, Object> helperFieldMap(String accept, String bodyTemplate, String contentType, HttpMethod method, String url) {
+  private static Map<String, Object> helperFieldMap(String accept, String bodyTemplate, String contentType, HttpMethod method, Boolean sendEmptyBody, String url) {
     final Map<String, Object> map = new HashMap<>();
 
-    map.put("accept", accept);
-    map.put("bodyTemplate", bodyTemplate);
-    map.put("contentType", contentType);
-    map.put("method", method);
-    map.put("url", url);
+    map.put(ACCEPT, accept);
+    map.put(BODYTEMPLATE, bodyTemplate);
+    map.put(CONTENTTYPE, contentType);
+    map.put(METHOD, method);
+    map.put(SENDEMPTYBODY, sendEmptyBody);
+    map.put(URL, url);
 
     return map;
   }

--- a/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
@@ -77,6 +77,6 @@ class EndEventTest {
     assertEquals(VALUE, getField(endEvent, "deserializeAs"));
   }
 
-  private static class Impl extends EndEvent { };
+  private static class Impl extends EndEvent { }
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
@@ -2,19 +2,41 @@ package org.folio.rest.workflow.model;
 
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class RequestTaskTest {
+
+  private static final String ASYNCAFTER            = "asyncAfter";
+  private static final String ASYNCBEFORE           = "asyncBefore";
+  private static final String DESCRIPTION           = "description";
+  private static final String DESERIALIZEAS         = "deserializeAs";
+  private static final String HEADEROUTPUTVARIABLES = "headerOutputVariables";
+  private static final String ID                    = "id";
+  private static final String INPUTVARIABLES        = "inputVariables";
+  private static final String NAME                  = "name";
+  private static final String OUTPUTVARIABLE        = "outputVariable";
+  private static final String REQUEST               = "request";
 
   @Mock
   private EmbeddedVariable embeddedVariable;
@@ -35,152 +57,295 @@ class RequestTaskTest {
 
   @Test
   void getIdWorksTest() {
-    setField(requestTask, "id", VALUE);
+    setField(requestTask, ID, VALUE);
 
     assertEquals(VALUE, requestTask.getId());
   }
 
   @Test
   void setIdWorksTest() {
-    setField(requestTask, "id", null);
+    setField(requestTask, ID, null);
 
     requestTask.setId(VALUE);
-    assertEquals(VALUE, getField(requestTask, "id"));
+    assertEquals(VALUE, getField(requestTask, ID));
   }
 
   @Test
   void getNameWorksTest() {
-    setField(requestTask, "name", VALUE);
+    setField(requestTask, NAME, VALUE);
 
     assertEquals(VALUE, requestTask.getName());
   }
 
   @Test
   void setNameWorksTest() {
-    setField(requestTask, "name", null);
+    setField(requestTask, NAME, null);
 
     requestTask.setName(VALUE);
-    assertEquals(VALUE, getField(requestTask, "name"));
+    assertEquals(VALUE, getField(requestTask, NAME));
   }
 
   @Test
   void getDescriptionWorksTest() {
-    setField(requestTask, "description", VALUE);
+    setField(requestTask, DESCRIPTION, VALUE);
 
     assertEquals(VALUE, requestTask.getDescription());
   }
 
   @Test
   void setDescriptionWorksTest() {
-    setField(requestTask, "description", null);
+    setField(requestTask, DESCRIPTION, null);
 
     requestTask.setDescription(VALUE);
-    assertEquals(VALUE, getField(requestTask, "description"));
+    assertEquals(VALUE, getField(requestTask, DESCRIPTION));
   }
 
   @Test
   void getDeserializeAsWorksTest() {
-    setField(requestTask, "deserializeAs", VALUE);
+    setField(requestTask, DESERIALIZEAS, VALUE);
 
     assertEquals(VALUE, requestTask.getDeserializeAs());
   }
 
   @Test
   void setDeserializeAsWorksTest() {
-    setField(requestTask, "deserializeAs", null);
+    setField(requestTask, DESERIALIZEAS, null);
 
     requestTask.setDeserializeAs(VALUE);
-    assertEquals(VALUE, getField(requestTask, "deserializeAs"));
+    assertEquals(VALUE, getField(requestTask, DESERIALIZEAS));
   }
 
   @Test
   void getInputVariablesWorksTest() {
-    setField(requestTask, "inputVariables", inputVariables);
+    setField(requestTask, INPUTVARIABLES, inputVariables);
 
     assertEquals(inputVariables, requestTask.getInputVariables());
   }
 
   @Test
   void setInputVariablesWorksTest() {
-    setField(requestTask, "inputVariables", null);
+    setField(requestTask, INPUTVARIABLES, null);
 
     requestTask.setInputVariables(inputVariables);
-    assertEquals(inputVariables, getField(requestTask, "inputVariables"));
+    assertEquals(inputVariables, getField(requestTask, INPUTVARIABLES));
   }
 
   @Test
   void getOutputVariableWorksTest() {
-    setField(requestTask, "outputVariable", embeddedVariable);
+    setField(requestTask, OUTPUTVARIABLE, embeddedVariable);
 
     assertEquals(embeddedVariable, requestTask.getOutputVariable());
   }
 
   @Test
   void setOutputVariableWorksTest() {
-    setField(requestTask, "outputVariable", null);
+    setField(requestTask, OUTPUTVARIABLE, null);
 
     requestTask.setOutputVariable(embeddedVariable);
-    assertEquals(embeddedVariable, getField(requestTask, "outputVariable"));
+    assertEquals(embeddedVariable, getField(requestTask, OUTPUTVARIABLE));
   }
 
   @Test
   void getAsyncBeforeWorksTest() {
-    setField(requestTask, "asyncBefore", true);
+    setField(requestTask, ASYNCBEFORE, true);
 
     assertEquals(true, requestTask.getAsyncBefore());
   }
 
   @Test
   void setAsyncBeforeWorksTest() {
-    setField(requestTask, "asyncBefore", false);
+    setField(requestTask, ASYNCBEFORE, false);
 
     requestTask.setAsyncBefore(true);
-    assertEquals(true, getField(requestTask, "asyncBefore"));
+    assertEquals(true, getField(requestTask, ASYNCBEFORE));
   }
 
   @Test
   void getAsyncAfterWorksTest() {
-    setField(requestTask, "asyncAfter", true);
+    setField(requestTask, ASYNCAFTER, true);
 
     assertEquals(true, requestTask.getAsyncAfter());
   }
 
   @Test
   void setAsyncAfterWorksTest() {
-    setField(requestTask, "asyncAfter", false);
+    setField(requestTask, ASYNCAFTER, false);
 
     requestTask.setAsyncAfter(true);
-    assertEquals(true, getField(requestTask, "asyncAfter"));
+    assertEquals(true, getField(requestTask, ASYNCAFTER));
   }
 
   @Test
   void getHeaderOutputVariablesWorksTest() {
-    setField(requestTask, "headerOutputVariables", inputVariables);
+    setField(requestTask, HEADEROUTPUTVARIABLES, inputVariables);
 
     assertEquals(inputVariables, requestTask.getHeaderOutputVariables());
   }
 
   @Test
   void setHeaderOutputVariablesWorksTest() {
-    setField(requestTask, "headerOutputVariables", null);
+    setField(requestTask, HEADEROUTPUTVARIABLES, null);
 
     requestTask.setHeaderOutputVariables(inputVariables);
-    assertEquals(inputVariables, getField(requestTask, "headerOutputVariables"));
+    assertEquals(inputVariables, getField(requestTask, HEADEROUTPUTVARIABLES));
   }
 
   @Test
   void getRequestWorksTest() {
-    setField(requestTask, "request", embeddedRequest);
+    setField(requestTask, REQUEST, embeddedRequest);
 
     assertEquals(embeddedRequest, requestTask.getRequest());
   }
 
   @Test
   void setRequestWorksTest() {
-    setField(requestTask, "request", null);
+    setField(requestTask, REQUEST, null);
 
     requestTask.setRequest(embeddedRequest);
-    assertEquals(embeddedRequest, getField(requestTask, "request"));
+    assertEquals(embeddedRequest, getField(requestTask, REQUEST));
+  }
+
+  @SuppressWarnings("unchecked")
+  @ParameterizedTest
+  @MethodSource("providePrePersistFor")
+  void prePersistWorksTest(Map<String, Object> initial, Map<String, Object> expected, Map<String, Boolean> persist) {
+
+    initial.forEach((String attribute, Object value) -> {
+      setField(requestTask, attribute, value);
+    });
+
+    requestTask.prePersist();
+
+    expected.forEach((String attribute, Object value) -> {
+      if (attribute == HEADEROUTPUTVARIABLES) {
+        final Set<EmbeddedVariable> eps = (Set<EmbeddedVariable>) value;
+
+        assertNotNull(getField(requestTask, attribute));
+        assertEquals(eps.size(), ((Set<EmbeddedVariable>) getField(requestTask, attribute)).size());
+
+        eps.forEach(ep -> {
+          if (ep != null) {
+            if (Boolean.TRUE.equals(persist.get(attribute))) {
+              verify(ep).prePersist();
+            } else if (Boolean.FALSE.equals(persist.get(attribute))) {
+              verify(ep, never()).prePersist();
+            }
+          }
+        });
+      } else {
+        assertEquals(value, getField(requestTask, attribute));
+      }
+    });
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSendEmptyBodyFor")
+  void prePersistSendEmptyBodyWorksTest(final Boolean sendEmptyBody, final String bodyTemplate, final String expected) {
+
+    final EmbeddedRequest er = new EmbeddedRequest();
+
+    setField(er, "sendEmptyBody", sendEmptyBody);
+    setField(er, "bodyTemplate", bodyTemplate);
+
+    er.prePersist();
+
+    assertEquals(expected, getField(er, "bodyTemplate"));
+  }
+
+  /**
+   * Helper function for parameterized tests for the prePersist function.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Arguments initial The initial values.
+   *     - Arguments expect  The expected values.
+   *     - Arguments persist Boolean representing whether or not this will call prePersist() on the object and if so, then true/false depending on verify.
+   */
+  private static Stream<Arguments> providePrePersistFor() {
+
+    final EmbeddedVariable variable = Mockito.spy(new EmbeddedVariable());
+    final EmbeddedVariable nullValue = null;
+    final Set<EmbeddedVariable> headerOutputVariables = Set.of(variable);
+    final Set<EmbeddedVariable> headerOutputVariablesEmpty = Set.of();
+    final Set<EmbeddedVariable> headerOutputVariablesNull = new HashSet<>();
+
+    headerOutputVariablesNull.add(nullValue);
+
+    return List.of(
+      Arguments.of(
+        helperFieldMap(null),
+        helperFieldMap(headerOutputVariablesEmpty),
+        helperPersistMap(false)
+      ),
+      Arguments.of(
+        helperFieldMap(headerOutputVariablesEmpty),
+        helperFieldMap(headerOutputVariablesEmpty),
+        helperPersistMap(false)
+      ),
+      Arguments.of(
+        helperFieldMap(headerOutputVariablesNull),
+        helperFieldMap(headerOutputVariablesNull),
+        helperPersistMap(false)
+      ),
+      Arguments.of(
+        helperFieldMap(headerOutputVariables),
+        helperFieldMap(headerOutputVariables),
+        helperPersistMap(true)
+      )
+    ).stream();
+  }
+
+  /**
+   * Helper function for parameterized tests for the prePersist function.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Arguments sendEmptyBody The initial sendEmptyBody value.
+   *     - Arguments bodyTemplate The initial bodyTemplate value.
+   *     - Arguments expect The expected bodyTemplate value.
+   */
+  private static Stream<Arguments> provideSendEmptyBodyFor() {
+
+    return List.of(
+      Arguments.of(true,  null,  "{}"),
+      Arguments.of(true,  "",    "{}"),
+      Arguments.of(false, null,  null),
+      Arguments.of(false, "",    null),
+      Arguments.of(true,  VALUE, VALUE),
+      Arguments.of(false, VALUE, VALUE)
+    ).stream();
+  }
+
+  /**
+   * Helper for reducing in line code repetition for assignments.
+   *
+   * @param headerOutputVariables The headerOutputVariables value.
+   *
+   * @return The built arguments map.
+   */
+  private static Map<String, Object> helperFieldMap(Set<EmbeddedVariable> headerOutputVariables) {
+
+    final Map<String, Object> map = new HashMap<>();
+
+    map.put(HEADEROUTPUTVARIABLES, headerOutputVariables);
+
+    return map;
+  }
+
+  /**
+   * Helper for reducing in line code repetition for assignments for persist setting.
+   *
+   * @param headerOutputVariables The headerOutputVariables persist value.
+   *
+   * @return The built persist map.
+   */
+  private static Map<String, Object> helperPersistMap(Boolean headerOutputVariables) {
+
+    final Map<String, Object> map = new HashMap<>();
+
+    map.put(HEADEROUTPUTVARIABLES, headerOutputVariables);
+
+    return map;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -108,9 +108,7 @@ public class EventController {
       .stream()
       .filter(name -> !name.equals("file"))
       .filter(name -> !name.equals("path"))
-      .forEach(name -> {
-        body.put(name, request.getParameter(name));
-      });
+      .forEach(name -> body.put(name, request.getParameter(name)));
 
     try (InputStream is = multipartFile.getInputStream()) {
       Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);

--- a/service/src/test/java/org/folio/rest/workflow/dto/TriggerDtoTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/dto/TriggerDtoTest.java
@@ -94,6 +94,6 @@ class TriggerDtoTest {
     assertEquals(VALUE, getField(triggerDto, "pathPattern"));
   }
 
-  private static class Impl extends Trigger implements TriggerDto { };
+  private static class Impl extends Trigger implements TriggerDto { }
 
 }


### PR DESCRIPTION
Resolves #161 .

Provide `sendEmptyBody` in such a way that existing behavior is preserved when `sendEmptyBody` is not defined.

When `sendEmptyBody` is TRUE, then the default value for the `bodyTemplate` must be `{}`. When `sendEmptyBody` is FALSE, then the default value for the `bodyTemplate` must be NULL.

Any non-null, non-empty, value in `bodyTemplate` should not be affected. The `sendEmptyBody` may be NULL to allow for this.

The default behavior is set to TRUE to preserve the existing behavior.

The `prePersists()` handles this logic so that the normal class instantiation can operate more practically. Setting the `bodyTemplate` to non-NULL in the initializer could cause problems (doing so in the `prePersists()` is safe).

Bring in the `prePersist()` behavior from upstream that happened when switching to Spring Boot 4.

Note: The issue was retroactively created so the branch name is inconsistent.