### PR TITLE
Issue 167: Back Port MODWRKFLOW-73: Delete all sub-nodes when deleting a workflow.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/dto/WorkflowOperationalNodeDto.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/WorkflowOperationalNodeDto.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.dto;
+
+import org.folio.rest.workflow.model.has.HasDeploymentId;
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasNodes;
+import org.folio.rest.workflow.model.has.HasVersionTag;
+
+/**
+ * This is a DTO designed for operational purposes that also has the associated Nodes.
+ *
+ * This is intended to be used for a proper delete operation.
+ */
+public interface WorkflowOperationalNodeDto extends HasDeploymentId, HasId, HasNodes, HasVersionTag {
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractProcess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractProcess.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.ColumnDefault;
 /**
  * Provides a superclass for any Node implementing a process, such as Subprocess.
  *
- * This is intended to reduce repitition of getters and setters needed by the DelegateTask.
+ * This is intended to reduce repetition of getters and setters needed by the DelegateTask.
  */
 @MappedSuperclass
 public abstract class AbstractProcess extends Node implements HasAsync, HasNodes {

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
@@ -13,6 +13,8 @@ import org.folio.rest.workflow.model.components.Task;
 import org.folio.rest.workflow.model.converter.EmbeddedVariableConverter;
 import org.folio.rest.workflow.model.has.HasInputOutput;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * Provides a superclass for any Node implementing a DelegateTask.
@@ -37,6 +39,7 @@ public abstract class AbstractTask extends Node implements HasInputOutput, Task 
   @Getter
   @Setter
   @ElementCollection
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Set<EmbeddedVariable> inputVariables;
 
   @Getter

--- a/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
@@ -7,6 +7,8 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 public class InputTask extends AbstractTask {
@@ -14,6 +16,7 @@ public class InputTask extends AbstractTask {
   @Getter
   @Setter
   @ElementCollection
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Set<EmbeddedInput> inputs;
 
   public InputTask() {

--- a/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.common.HasRequestTaskCommon;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * A task for regular HTTP requests.
@@ -22,6 +24,7 @@ public class RequestTask extends AbstractTask implements DelegateTask, HasReques
   @Getter
   @Setter
   @ElementCollection
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Set<EmbeddedVariable> headerOutputVariables;
 
   @Getter

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -39,6 +39,8 @@ import org.folio.rest.workflow.model.has.HasVersionTag;
 import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
 import org.folio.spring.domain.model.AbstractBaseEntity;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.Version;
 
 @Entity
@@ -88,6 +90,7 @@ public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCrea
   @MapKeyColumn(name = "context_key")
   @Column(name = "context_value")
   @Convert(converter = JsonNodeConverter.class, attributeName = "value")
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Map<String, JsonNode> initialContext;
 
   @Getter

--- a/components/src/test/java/org/folio/rest/workflow/dto/WorkflowOperationalDtoTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/dto/WorkflowOperationalDtoTest.java
@@ -48,6 +48,6 @@ class WorkflowOperationalDtoTest {
     assertEquals(VALUE, getField(workflowDto, "deploymentId"));
   }
 
-  private static class Impl extends Workflow implements WorkflowOperationalDto { };
+  private static class Impl extends Workflow implements WorkflowOperationalDto { }
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/dto/WorkflowOperationalNodeDtoTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/dto/WorkflowOperationalNodeDtoTest.java
@@ -1,0 +1,99 @@
+package org.folio.rest.workflow.dto;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+import org.folio.rest.workflow.model.Node;
+import org.folio.rest.workflow.model.StartEvent;
+import org.folio.rest.workflow.model.Workflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowOperationalNodeDtoTest {
+
+  private static final StartEvent NODE = new StartEvent();
+
+  private static final List<Node> NODES = List.of(NODE);
+
+  private WorkflowOperationalNodeDto dto;
+
+  @BeforeEach
+  void beforeEach() {
+
+    dto = new Impl();
+  }
+
+  @Test
+  void getDeploymentIdWorksTest() {
+
+    setField(dto, "deploymentId", VALUE);
+
+    assertEquals(VALUE, dto.getDeploymentId());
+  }
+
+  @Test
+  void setDeploymentIdWorksTest() {
+
+    setField(dto, "deploymentId", null);
+
+    dto.setDeploymentId(VALUE);
+    assertEquals(VALUE, getField(dto, "deploymentId"));
+  }
+
+  @Test
+  void getIdWorksTest() {
+
+    setField(dto, "id", VALUE);
+
+    assertEquals(VALUE, dto.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+
+    setField(dto, "id", null);
+
+    dto.setId(VALUE);
+    assertEquals(VALUE, getField(dto, "id"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+
+    setField(dto, "nodes", NODES);
+
+    assertEquals(NODES, dto.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+
+    setField(dto, "nodes", null);
+
+    dto.setNodes(NODES);
+    assertEquals(NODES, getField(dto, "nodes"));
+  }
+
+  @Test
+  void getVersionTagWorksTest() {
+
+    setField(dto, "versionTag", VALUE);
+
+    assertEquals(VALUE, dto.getVersionTag());
+  }
+
+  @Test
+  void setVersionTagWorksTest() {
+
+    setField(dto, "versionTag", null);
+
+    dto.setVersionTag(VALUE);
+    assertEquals(VALUE, getField(dto, "versionTag"));
+  }
+
+  private static class Impl extends Workflow implements WorkflowOperationalNodeDto { }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Each entity, etc.., must be found and explicitly deleted.
  */
 @Service
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class DeleteService {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeleteService.class);

--- a/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
@@ -1,0 +1,218 @@
+package org.folio.rest.workflow.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.folio.rest.workflow.dto.WorkflowOperationalNodeDto;
+import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
+import org.folio.rest.workflow.model.Node;
+import org.folio.rest.workflow.model.resolver.DeserializeAsNodeJsonResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * A class to facilitate recursive deletion of workflows.
+ *
+ * Workflows does not use SQL relations.
+ * Each entity, etc.., must be found and explicitly deleted.
+ */
+@Service
+@Transactional
+public class DeleteService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteService.class);
+
+  static final List<String> NODE_ENTITIES = List.of(
+    "EventSubprocess",
+    "ExclusiveGateway",
+    "InclusiveGateway",
+    "MoveToLastGateway",
+    "MoveToNode",
+    "ParallelGateway",
+    "Subprocess"
+  );
+
+  static final List<String> SIMPLE_ENTITIES = List.of(
+    "CompressFileTask",
+    "Condition",
+    "ConnectTo",
+    "DatabaseConnectionTask",
+    "DatabaseDisconnectTask",
+    "DatabaseQueryTask",
+    "DirectoryTask",
+    "EmailTask",
+    "EndEvent",
+    "FileTask",
+    "FolioRequestTask",
+    "FtpTask",
+    "InputTask",
+    "ProcessorTask",
+    "ReceiveTask",
+    "RequestTask",
+    "ScriptTask",
+    "StartEvent"
+  );
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  DeleteService() {
+    // Do nothing, the @PersistenceContext handles entityManager.
+  }
+
+  /**
+   * Recursively delete all associated nodes.
+   *
+   * @param workflow The workflow to delete the nodes of.
+   *
+   * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
+   */
+  public void deleteNodes(WorkflowOperationalNodeDto workflow) {
+
+    final List<Node> nodes = workflow.getNodes();
+
+    if (nodes == null || nodes.isEmpty()) return;
+
+    nodes.forEach(node -> deleteEntity(node.getDeserializeAs(), node.getId()));
+  }
+
+  /**
+   * Delete id for the given entity using the serialize as name.
+   *
+   * @param name The serialize as name for an entity.
+   * @param id   The ID of the row to delete.
+   */
+  void deleteEntity(String name, String id) {
+
+    if (name == null || id == null) {
+      LOG.warn("Cannot delete with entity name '{}' and id '{}', both values must not be NULL.", name, id);
+
+      return;
+    }
+
+    String entityName = extractEntityName(SIMPLE_ENTITIES, name);
+
+    if (entityName == null) {
+      entityName = extractEntityName(NODE_ENTITIES, name);
+
+      if (entityName == null) {
+        LOG.warn("Unknown name '{}' for id '{}', got entityName '{}'.", name, id, entityName);
+
+        return;
+      }
+
+      deleteNodeEntity(entityName, id);
+    }
+
+    deleteSimpleEntity(entityName, id);
+  }
+
+  /**
+   * Delete node entities using the serialize as name.
+   *
+   * For use by those that implement `hasNode`.
+   *
+   * This must recurse the date.
+   *
+   * @param entityName The entity name for direct use in SQL.
+   * @param id         The ID of the row to delete.
+   */
+  void deleteNodeEntity(String entityName, String id) {
+
+    for (final Map.Entry<String, String> entry : findNodeTables(entityName, id).entrySet()) {
+      deleteEntity(entry.getValue(), entry.getKey());
+    }
+  }
+
+  /**
+   * Delete simple entities using the serialize as name.
+   *
+   * Do not use this to delete complex entities, such as those that implement `hasNode`.
+   *
+   * @param entityName The entity name for direct use in SQL.
+   * @param id         The ID of the row to delete.
+   */
+  @SuppressWarnings("S2077") // SonarQube false positive, the query is protected by extractEntityName() and cannot produce SQL escapes from entityName.
+  void deleteSimpleEntity(String entityName, String id) {
+
+    final int total = entityManager.createQuery("DELETE FROM " + entityName + " e WHERE e.id = :id")
+      .setParameter("id", id)
+      .executeUpdate();
+
+    if (total > 0) {
+      entityManager.clear();
+    }
+
+    LOG.debug("Deleted '{}' entities for entityName '{}' with id '{}'.", total, entityName, id);
+  }
+
+  /**
+   * Attempt to match the entity in the list and return the list value.
+   *
+   * The match is case-insensitive.
+   *
+   * @param list The list to search through.
+   * @param name The entity serialize as name.
+   *
+   * @return The entity name for direct use in SQL.
+   */
+  String extractEntityName(List<String> list, String name) {
+
+    final Optional<String> match = list.stream()
+      .filter(s -> s.equalsIgnoreCase(name))
+      .findFirst();
+
+    return match.isEmpty() ? null : match.get();
+  }
+
+  /**
+   * Build a list of all nodes and their associated tables associated with the given ID.
+   *
+   * @param entityName The entity name for direct use in SQL.
+   * @param id         The ID of the row to fetch the associated nodes of.
+   *
+   * @return A map where the key represents the ID and the value represents the table.
+   */
+  @SuppressWarnings("unchecked")
+  Map<String, String> findNodeTables(String entityName, String id) {
+
+    final String query = findNodeTablesBuildQuery(entityName, id);
+
+    final List<Object[]> results = entityManager.createNativeQuery(query).getResultList();
+
+    final Map<String, String> map = new HashMap<>();
+
+    for (final Object[] row : results) {
+      if (row.length >= 2) {
+        map.put(String.valueOf(row[0]), String.valueOf(row[1]));
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Build the query for finding all entities associated with a node.
+   *
+   * @param entityName The entity name for direct use in SQL.
+   * @param id         The ID of the row to fetch the associated nodes of.
+   *
+   * @return The generated SQL query.
+   */
+  String findNodeTablesBuildQuery(String entityName, String id) {
+
+    final String entity = entityName.toLowerCase();
+
+    return DeserializeAsNodeJsonResolver.CLASSES.keySet().stream()
+      .map(String::toLowerCase)
+      .map(s -> String.format("SELECT t.id, '%s' FROM %s t INNER JOIN %s_node n ON n.nodes_id = t.id WHERE n.%s_id = '%s'", s, s, entity, entity, id))
+      .collect(Collectors.joining(" UNION "));
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -96,7 +96,7 @@ public class WorkflowEngineService {
    *
    * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
    */
-  @Transactional
+  @Transactional(rollbackFor = Exception.class)
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -11,6 +11,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
+import org.folio.rest.workflow.dto.WorkflowOperationalNodeDto;
 import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
@@ -24,6 +25,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -56,13 +58,16 @@ public class WorkflowEngineService {
   @Value("${okapi.camunda.rest-path:/camunda}")
   private String restPath;
 
+  private DeleteService deleteService;
+
   private WorkflowRepo workflowRepo;
 
   private JsonMapper mapper;
 
   private RestTemplate restTemplate;
 
-  public WorkflowEngineService(WorkflowRepo workflowRepo, JsonMapper mapper, RestTemplateBuilder restTemplateBuilder) {
+  public WorkflowEngineService(DeleteService deleteService, WorkflowRepo workflowRepo, JsonMapper mapper, RestTemplateBuilder restTemplateBuilder) {
+    this.deleteService = deleteService;
     this.workflowRepo = workflowRepo;
     this.mapper = mapper;
     this.restTemplate = restTemplateBuilder.build();
@@ -85,47 +90,24 @@ public class WorkflowEngineService {
   /**
    * Delete the Workflow from the given Workflow ID.
    *
-   * To be removed. This is just an experiment.
-   *
    * @param workflowId ID of the Workflow to delete.
    * @param tenant The tenant to use.
    * @param token The token to use.
    *
    * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
    */
+  @Transactional
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    final WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
-    final String id = workflow.getDeploymentId();
-    final String version = workflow.getVersionTag();
+    final WorkflowOperationalNodeDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalNodeDto.class);
 
-    // Deployment ID will not exist if it has never been activated.
-    if (id != null) {
-      final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(id, version, tenant, token);
-
-      if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
-        final ArrayNode definitions = response.hasBody()
-          ? response.getBody()
-          : null;
-
-        if (definitions != null && response.getStatusCode() != HttpStatus.NOT_FOUND && !definitions.isEmpty()) {
-          try {
-            deactivate(workflowId, tenant, token);
-          } catch (WorkflowEngineServiceException e) {
-            final String message = String.format(
-              "Failed to delete Workflow ID '%s' for Deployment ID '%s' and Version Tag '%s' due to deactivation failure: %s!",
-              workflowId,
-              id,
-              version,
-              e.getMessage()
-            );
-
-            throw new WorkflowEngineServiceException(message, e);
-          }
-        }
-      }
+    // Deployment ID will not exist if it has not been activated.
+    if (workflow.getDeploymentId() != null) {
+      deleteDeployment(workflow, tenant, token);
     }
+
+    deleteService.deleteNodes(workflow);
 
     workflowRepo.deleteById(workflowId);
   }
@@ -207,6 +189,47 @@ public class WorkflowEngineService {
     }
 
     return instances;
+  }
+
+  /**
+   * Delete the deployed workflow.
+   *
+   * @param workflow The workflow to delete the deployment of.
+   * @param tenant   The tenant to use.
+   * @param token    The token to use.
+   *
+   * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
+   */
+  private void deleteDeployment(WorkflowOperationalNodeDto workflow, String tenant, String token) throws WorkflowEngineServiceException {
+
+    final String deploymentId = workflow.getDeploymentId();
+    final String id = workflow.getId();
+    final String version = workflow.getVersionTag();
+
+    final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(deploymentId, version, tenant, token);
+
+    if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
+
+      final ArrayNode definitions = response.hasBody()
+        ? response.getBody()
+        : null;
+
+      if (definitions != null && response.getStatusCode() != HttpStatus.NOT_FOUND && !definitions.isEmpty()) {
+        try {
+          deactivate(id, tenant, token);
+        } catch (WorkflowEngineServiceException e) {
+          final String message = String.format(
+            "Failed to delete Workflow ID '%s' for Deployment ID '%s' and Version Tag '%s' due to deactivation failure: %s!",
+            id,
+            deploymentId,
+            version,
+            e.getMessage()
+          );
+
+          throw new WorkflowEngineServiceException(message, e);
+        }
+      }
+    }
   }
 
   /**

--- a/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
@@ -143,6 +143,24 @@ class DeleteServiceTest {
   }
 
   @Test
+  void deleteNodesForSimpleWithNoDeletionsTest() {
+
+    nodes.add(startEvent);
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(0);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery).executeUpdate();
+  }
+
+  @Test
   void deleteNodesForNodeWithoutChildrenTest() {
 
     final List<Object[]> results = new ArrayList<>();

--- a/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
@@ -1,0 +1,315 @@
+package org.folio.rest.workflow.service;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.dto.WorkflowOperationalNodeDto;
+import org.folio.rest.workflow.model.Node;
+import org.folio.rest.workflow.model.StartEvent;
+import org.folio.rest.workflow.model.Subprocess;
+import org.folio.rest.workflow.model.Workflow;
+import org.folio.rest.workflow.model.has.HasNodes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteServiceTest {
+
+  /**
+   * Needed to test using different IDs.
+   */
+  private static final String UUID_ALT = "d2ad0ddb-8f0a-40e6-b543-1f43d62b8a95";
+
+  /**
+   * Needed to test using different names.
+   */
+  private static final String VALUE_ALT = "value_alt";
+
+  @Mock
+  private EntityManager entityManager;
+
+  @Mock
+  private TypedQuery<?> typedQuery;
+
+  @Spy
+  private DeleteService deleteService;
+
+  private List<Node> nodes;
+
+  private StartEvent startEvent;
+
+  private Subprocess subprocess;
+
+  private WorkflowAsOperationalNodeDto workflowOperationalNode;
+
+  @BeforeEach
+  void beforeEach() {
+
+    nodes = new ArrayList<>();
+    startEvent = new StartEvent();
+    subprocess = new Subprocess();
+    workflowOperationalNode = new WorkflowAsOperationalNodeDto();
+
+    setField(deleteService, "entityManager", entityManager);
+
+    setField(workflowOperationalNode, "id", UUID);
+    setField(workflowOperationalNode, "deploymentId", UUID);
+    setField(workflowOperationalNode, "name", VALUE);
+    setField(workflowOperationalNode, "nodes", nodes);
+    setField(workflowOperationalNode, "versionTag", VALUE);
+
+    setField(startEvent, "id", UUID);
+    setField(startEvent, "name", VALUE);
+
+    setField(subprocess, "id", UUID_ALT);
+    setField(subprocess, "name", VALUE_ALT);
+  }
+
+  @Test
+  void deleteNodesReturnsOnNullTest() {
+
+    setField(workflowOperationalNode, "nodes", null);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(deleteService, never()).deleteEntity(VALUE, UUID);
+  }
+
+  @Test
+  void deleteNodesReturnsOnEmptyTest() {
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(deleteService, never()).deleteEntity(VALUE, UUID);
+  }
+
+  @Test
+  void deleteNodesNoDeserializeAsTest() {
+
+    final NoSerializeNode node = new NoSerializeNode();
+
+    setField(node, "id", UUID);
+
+    nodes.add(node);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(deleteService, never()).deleteEntity(VALUE, UUID);
+  }
+
+  @Test
+  void deleteNodesNoIdTest() {
+
+    setField(startEvent, "id", null);
+
+    nodes.add(startEvent);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(deleteService, never()).deleteEntity(VALUE, UUID);
+  }
+
+  @Test
+  void deleteNodesForSimpleTest() {
+
+    nodes.add(startEvent);
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(1);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery).executeUpdate();
+  }
+
+  @Test
+  void deleteNodesForNodeWithoutChildrenTest() {
+
+    final List<Object[]> results = new ArrayList<>();
+
+    nodes.add(subprocess);
+
+    when(entityManager.createNativeQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.getResultList()).thenAnswer(invocation -> {
+      return results;
+    });
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(1);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery).executeUpdate();
+  }
+
+  @Test
+  void deleteNodesForNodeWithChildrenTest() {
+
+    final String id = (String) getField(startEvent, "id");
+    final String[] child = new String[] { id, StartEvent.class.getSimpleName() };
+
+    final List<Object[]> results = new ArrayList<>();
+    results.add(child);
+
+    nodes.add(subprocess);
+
+    when(entityManager.createNativeQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.getResultList()).thenAnswer(invocation -> {
+      return results;
+    });
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(1);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery, times(2)).executeUpdate();
+  }
+
+  @Test
+  void deleteNodesForNodeWithChildrenIncompleteRowsTest() {
+
+    final String[] child = new String[] { "" };
+
+    final List<Object[]> results = new ArrayList<>();
+    results.add(child);
+
+    nodes.add(subprocess);
+
+    when(entityManager.createNativeQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.getResultList()).thenAnswer(invocation -> {
+      return results;
+    });
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(1);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery).executeUpdate();
+  }
+
+  @Test
+  void deleteNodesForUnknownNodeTest() {
+
+    final UnknownNode node = new UnknownNode();
+
+    setField(node, "id", UUID);
+    setField(node, "name", VALUE);
+
+    nodes.add(node);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery, never()).executeUpdate();
+  }
+
+  @Test
+  void deleteNodesForMaliciousNodeTest() {
+
+    final MaliciousNode node = new MaliciousNode();
+
+    setField(node, "id", UUID);
+    setField(node, "name", VALUE);
+
+    nodes.add(node);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery, never()).executeUpdate();
+  }
+
+  /**
+   * Mocked node that is intended to return nothing when the getDeserializeAs() is called.
+   */
+  private class NoSerializeNode extends Node {
+
+    @Override
+    public String getDeserializeAs() {
+
+      return null;
+    }
+
+  }
+
+  /**
+   * Mocked node that is intended to return an unknown entity name when the getDeserializeAs() is called and has nodes.
+   */
+  private class UnknownNode extends Node implements HasNodes {
+
+    private final List<Node> list = new ArrayList<>();
+
+    @Override
+    public String getDeserializeAs() {
+
+      return "This Should Not Match";
+    }
+
+    @Override
+    public List<Node> getNodes() {
+
+      return list;
+    }
+
+    @Override
+    public void setNodes(List<Node> nodes) {
+
+      nodes.forEach(list::add);
+    }
+
+  }
+
+  /**
+   * Mocked node that is intended to return a malicious SQL string when the getDeserializeAs() is called.
+   */
+  private class MaliciousNode extends Node {
+
+    @Override
+    public String getDeserializeAs() {
+
+      return "workflow; SELECT * from workflow";
+    }
+
+  }
+
+  private class WorkflowAsOperationalNodeDto extends Workflow implements WorkflowOperationalNodeDto {}
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -29,11 +29,14 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.List;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
+import org.folio.rest.workflow.dto.WorkflowOperationalNodeDto;
 import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
+import org.folio.rest.workflow.model.Node;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +66,9 @@ class WorkflowEngineServiceTest {
   private static final String PROCESS_DEFINITION = "process-definition";
 
   @Mock
+  private DeleteService deleteService;
+
+  @Mock
   private WorkflowRepo workflowRepo;
 
   @Mock
@@ -72,7 +78,11 @@ class WorkflowEngineServiceTest {
 
   private WorkflowAsOperationalDto workflowOperational;
 
+  private WorkflowAsOperationalNodeDto workflowOperationalNode;
+
   private WorkflowEngineService workflowEngineService;
+
+  private  List<Node> nodes;
 
   private JsonMapper mapper;
 
@@ -87,7 +97,9 @@ class WorkflowEngineServiceTest {
       .addModule(new JavaTimeModule())
       .build();
 
-    workflowEngineService = new WorkflowEngineService(workflowRepo, mapper, new RestTemplateBuilder());
+    workflowEngineService = new WorkflowEngineService(deleteService, workflowRepo, mapper, new RestTemplateBuilder());
+
+    nodes = List.of();
 
     workflow = new WorkflowAsDto();
     workflow.setId(UUID);
@@ -99,6 +111,13 @@ class WorkflowEngineServiceTest {
     workflowOperational.setDeploymentId(UUID);
     workflowOperational.setName(VALUE);
     workflowOperational.setVersionTag(VALUE);
+
+    workflowOperationalNode = new WorkflowAsOperationalNodeDto();
+    workflowOperationalNode.setId(UUID);
+    workflowOperationalNode.setDeploymentId(UUID);
+    workflowOperationalNode.setName(VALUE);
+    workflowOperationalNode.setNodes(nodes);
+    workflowOperationalNode.setVersionTag(VALUE);
 
     setField(workflowEngineService, "workflowRepo", workflowRepo);
     setField(workflowEngineService, "restTemplate", restTemplate);
@@ -178,7 +197,7 @@ class WorkflowEngineServiceTest {
 
     final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalNodeDto.class))).thenReturn(workflowOperationalNode);
     when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
 
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
@@ -188,6 +207,8 @@ class WorkflowEngineServiceTest {
       .thenReturn(responseEntity);
 
     when(workflowRepo.save(any())).thenReturn(workflow);
+
+    doNothing().when(deleteService).deleteNodes(any(WorkflowOperationalNodeDto.class));
     doNothing().when(workflowRepo).deleteById(anyString());
 
     workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -203,11 +224,12 @@ class WorkflowEngineServiceTest {
 
     ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
 
-    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalNodeDto.class))).thenReturn(workflowOperationalNode);
 
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(responseArray);
 
+    doNothing().when(deleteService).deleteNodes(any(WorkflowOperationalNodeDto.class));
     doNothing().when(workflowRepo).deleteById(anyString());
 
     workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -232,7 +254,7 @@ class WorkflowEngineServiceTest {
 
     final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalNodeDto.class))).thenReturn(workflowOperationalNode);
     when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
 
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
@@ -264,7 +286,7 @@ class WorkflowEngineServiceTest {
 
     final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalNodeDto.class))).thenReturn(workflowOperationalNode);
     when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
 
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
@@ -299,7 +321,7 @@ class WorkflowEngineServiceTest {
 
     final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalNodeDto.class))).thenReturn(workflowOperationalNode);
     when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
 
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
@@ -765,5 +787,7 @@ class WorkflowEngineServiceTest {
   private class WorkflowAsDto extends Workflow implements WorkflowDto {}
 
   private class WorkflowAsOperationalDto extends Workflow implements WorkflowOperationalDto {}
+
+  private class WorkflowAsOperationalNodeDto extends Workflow implements WorkflowOperationalNodeDto {}
 
 }


### PR DESCRIPTION
Resolves #167 .

Add a new DTO with associated unit test for providing the ID and nodes.

Get the nodes from this workflow and delete those first.

The database structure is generated and there is no repo or anything like that to directly call for deletion. The nodes are not associated with foreign keys in the database across all fields. The `ON DELETE CASCADE` behavior is not useful, except for the embeddables.

Add on delete actions defaults where possible.

Avoid addng `@ManyToOne` or `@OneToMany` to avoid possible regressions, such as performance regressions. The goal here is not to redesign the database structure.

Use the entity manager to perform custom **SQL** that shall perform the deletions. The list of nodes on the **Workflow** is not the complete list of nodes. Therefore, each entity that has a `_nodes` table must also be recursively parsed.

Use existing code to help build and dynamically construct the appropriate **SQL**. The `DeserializeAsNodeJsonResolver.CLASSES` should probably be move to another class. Doing so would introduce more changes than desired for now so this is avoided.

Add a debug logger to make the deletions easier to confirm/deny.

Remove the invalid/outdated comment "To be removed. This is just an experiment.".

Add `@Transactional` to the delete function in `WorkflowEngineService`.

For **Spring Boot 3**, Add `entityManager.clear();` to prevent errors like:
> StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) after using entitymanager to execute explicit delete query