### PR TITLE
Issue 170: Back port MODWRKFLOW-74: Support dash '-' in parameter sanitization for UUID.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -39,7 +39,7 @@ public class WorkflowController {
 
   private static final Log LOG = LogFactory.getLog(WorkflowController.class);
 
-  private static final Pattern REGX_NOT_GRAPH = Pattern.compile("[^\\p{C}]");
+  private static final Pattern REGX_NOT_GRAPH_DASH = Pattern.compile("[^\\w-]+", Pattern.UNICODE_CHARACTER_CLASS);
   private static final Pattern REGX_EOL = Pattern.compile("[\r\n]");
 
   private WorkflowEngineService workflowEngineService;
@@ -167,7 +167,7 @@ public class WorkflowController {
   private String sanitize(String param) {
     if (param == null) return "";
 
-    final Matcher matchNotGraph = REGX_NOT_GRAPH.matcher(param);
+    final Matcher matchNotGraph = REGX_NOT_GRAPH_DASH.matcher(param);
     final Matcher matchEol = REGX_EOL.matcher(matchNotGraph.replaceAll(""));
 
     return matchEol.replaceAll(" ");

--- a/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
@@ -108,11 +108,15 @@ class WorkflowControllerTest {
 
   private static final String UUID = "aec4faca-8c3d-4b3b-a943-6003636991c0";
 
+  private static final String UUID_INVALID = "+";
+
   private static final String PATH_ACTIVATE = PATH + "/" + UUID + "/activate";
 
   private static final String PATH_DEACTIVATE = PATH + "/" + UUID + "/deactivate";
 
   private static final String PATH_DELETE = PATH + "/" + UUID + "/delete";
+
+  private static final String PATH_DELETE_INVALID = PATH + "/" + UUID_INVALID + "/delete";
 
   private static final String PATH_GET = PATH + "/" + UUID;
 
@@ -120,7 +124,9 @@ class WorkflowControllerTest {
 
   private static final String PATH_START = PATH + "/" + UUID + "/start";
 
-  private static final MultiValueMap<String, String> ID_PARAM = CollectionUtils.toMultiValueMap(Map.of(ID, List.of(UUID))); 
+  private static final MultiValueMap<String, String> ID_PARAM = CollectionUtils.toMultiValueMap(Map.of(ID, List.of(UUID)));
+
+  private static final MultiValueMap<String, String> ID_INVALID_PARAM = CollectionUtils.toMultiValueMap(Map.of(ID, List.of(UUID_INVALID)));
 
   private static final MultiValueMap<String, String> LIM_PARAM = CollectionUtils.toMultiValueMap(Map.of(
     LIMIT, List.of(LIMIT_VALUE)
@@ -271,6 +277,19 @@ class WorkflowControllerTest {
     Assertions.assertThatThrownBy(() -> {
       MockHttpServletRequestBuilder request = appendHeaders(delete(PATH_DELETE), OKAPI_HEAD_TENANT, APP_JSON, APP_JSON);
       request = appendParameters(request, ID_PARAM);
+
+      mvc.perform(request)
+        .andDo(log()).andExpect(status().is(404));
+    }).hasCauseInstanceOf(WorkflowNotFoundException.class);
+  }
+
+  @Test
+  void deleteWorkflowThrowsNotFoundInvalidIdSanitizeTest() throws Exception {
+    lenient().doThrow(WorkflowNotFoundException.class).when(workflowEngineService).exists(anyString());
+
+    Assertions.assertThatThrownBy(() -> {
+      MockHttpServletRequestBuilder request = appendHeaders(delete(PATH_DELETE_INVALID), OKAPI_HEAD_TENANT, APP_JSON, APP_JSON);
+      request = appendParameters(request, ID_INVALID_PARAM);
 
       mvc.perform(request)
         .andDo(log()).andExpect(status().is(404));


### PR DESCRIPTION
Resolves #170 .

Back port of https://github.com/folio-org/mod-workflow/pull/168 ([MODWRKFLOW-74](https://folio-org.atlassian.net/browse/MODWRKFLOW-74)).

Support dash '-' in parameter sanitization for UUID.